### PR TITLE
feat: add GitHub PR stacking

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
         "babel-preset-solid": "1.9.12",
         "citty": "^0.2.0",
         "diff": "^8.0.2",
+        "effect": "4.0.0-beta.65",
         "fuzzysort": "^3.1.0",
         "ghostty-opentui": "^1.4.12",
         "jsonc-parser": "^3.3.1",
@@ -116,6 +117,18 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
+    "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ=="],
+
+    "@msgpackr-extract/msgpackr-extract-darwin-x64": ["@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-arm": ["@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4", "", { "os": "linux", "cpu": "arm" }, "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-arm64": ["@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-x64": ["@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ=="],
+
+    "@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4", "", { "os": "win32", "cpu": "x64" }, "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ=="],
+
     "@opentui/core": ["@opentui/core@0.4.1", "", { "dependencies": { "bun-ffi-structs": "0.2.3", "diff": "9.0.0", "marked": "17.0.1", "string-width": "7.2.0", "strip-ansi": "7.1.2" }, "optionalDependencies": { "@opentui/core-darwin-arm64": "0.4.1", "@opentui/core-darwin-x64": "0.4.1", "@opentui/core-linux-arm64": "0.4.1", "@opentui/core-linux-arm64-musl": "0.4.1", "@opentui/core-linux-x64": "0.4.1", "@opentui/core-linux-x64-musl": "0.4.1", "@opentui/core-win32-arm64": "0.4.1", "@opentui/core-win32-x64": "0.4.1" }, "peerDependencies": { "web-tree-sitter": "0.25.10" } }, "sha512-ejlunoFCGLcghYGdfamI/DlWHsgCTLbuoL2JeOmFuLsN+DM5phje3CQbGR4tpl24cadCgHJQFomjoQ9Htvin+Q=="],
 
     "@opentui/core-darwin-arm64": ["@opentui/core-darwin-arm64@0.4.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ocs73hj9n0zLArOTpUWIXCWU6ERThG+3wQzO78EvfaR4hb5FRrDHGKWTzXpr6ukSKsUtKdztK5XYTPsJ5e3vww=="],
@@ -157,6 +170,8 @@
     "@shikijs/types": ["@shikijs/types@3.21.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-zGrWOxZ0/+0ovPY7PvBU2gIS9tmhSUUt30jAcNV0Bq0gb2S98gwfjIs1vxlmH5zM7/4YxLamT6ChlqqAJmPPjA=="],
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@takumi-rs/core": ["@takumi-rs/core@0.65.0", "", { "optionalDependencies": { "@takumi-rs/core-darwin-arm64": "0.65.0", "@takumi-rs/core-darwin-x64": "0.65.0", "@takumi-rs/core-linux-arm64-gnu": "0.65.0", "@takumi-rs/core-linux-arm64-musl": "0.65.0", "@takumi-rs/core-linux-x64-gnu": "0.65.0", "@takumi-rs/core-linux-x64-musl": "0.65.0", "@takumi-rs/core-win32-arm64-msvc": "0.65.0", "@takumi-rs/core-win32-x64-msvc": "0.65.0" } }, "sha512-lBNG+NRc602ul7Kxy9UohlbnFLVyloQP/DTxQzyNH+8khpdaIQTxpdHouzRzxf6upRDVDIVX5TG8oT16jKUAvQ=="],
 
@@ -236,9 +251,13 @@
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
     "diff": ["diff@8.0.2", "", {}, "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg=="],
+
+    "effect": ["effect@4.0.0-beta.65", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.6.0", "find-my-way-ts": "^0.1.6", "ini": "^6.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^1.11.9", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^13.0.0", "yaml": "^2.8.3" } }, "sha512-QYKvQPAj3CmtsvWkHQww15wX4KG2gNsszDWEcOO5sZCMknp66u6Si/Opmt3wwWCwsyvRmDAdIg+JIz5qzbbFIw=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.267", "", {}, "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw=="],
 
@@ -248,7 +267,11 @@
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
+    "fast-check": ["fast-check@4.8.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg=="],
+
     "find-babel-config": ["find-babel-config@2.1.2", "", { "dependencies": { "json5": "^2.2.3" } }, "sha512-ZfZp1rQyp4gyuxqt1ZqjFGVeVBvmpURMqdIWXbPRfB97Bf6BzdK/xSIbylEINzQ0kB5tlDQfn9HkNXXWsqTqLg=="],
+
+    "find-my-way-ts": ["find-my-way-ts@0.1.6", "", {}, "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA=="],
 
     "find-up": ["find-up@3.0.0", "", { "dependencies": { "locate-path": "^3.0.0" } }, "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg=="],
 
@@ -276,6 +299,8 @@
 
     "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
+    "ini": ["ini@6.0.0", "", {}, "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ=="],
+
     "is-core-module": ["is-core-module@2.16.1", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
@@ -285,6 +310,8 @@
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
     "jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
+
+    "kubernetes-types": ["kubernetes-types@1.30.0", "", {}, "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q=="],
 
     "locate-path": ["locate-path@3.0.0", "", { "dependencies": { "p-locate": "^3.0.0", "path-exists": "^3.0.0" } }, "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A=="],
 
@@ -312,7 +339,15 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "msgpackr": ["msgpackr@1.12.1", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.2" } }, "sha512-4EUH9tQHnMmEgzW/MdAP0KIfa1T9AF+htl0ffe2n5vb2EKn9y2co8ccpgWko6S52Jy1PQZKwRnx5/KkYjtd9MQ=="],
+
+    "msgpackr-extract": ["msgpackr-extract@3.0.4", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw=="],
+
+    "multipasta": ["multipasta@0.2.7", "", {}, "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA=="],
+
     "nanoid": ["nanoid@5.1.6", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg=="],
+
+    "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
 
     "node-releases": ["node-releases@2.0.27", "", {}, "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA=="],
 
@@ -339,6 +374,8 @@
     "pkg-up": ["pkg-up@3.1.0", "", { "dependencies": { "find-up": "^3.0.0" } }, "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA=="],
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
+
+    "pure-rand": ["pure-rand@8.4.0", "", {}, "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A=="],
 
     "react": ["react@19.2.3", "", {}, "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA=="],
 
@@ -378,6 +415,8 @@
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
+    "toml": ["toml@4.1.1", "", {}, "sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw=="],
+
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
@@ -396,6 +435,8 @@
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
+    "uuid": ["uuid@13.0.2", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw=="],
+
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
@@ -405,6 +446,8 @@
     "web-tree-sitter": ["web-tree-sitter@0.25.10", "", { "peerDependencies": { "@types/emscripten": "^1.40.0" }, "optionalPeers": ["@types/emscripten"] }, "sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA=="],
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 

--- a/docs/specs/github-stacking.md
+++ b/docs/specs/github-stacking.md
@@ -26,8 +26,8 @@ This keeps the hierarchy meaningful while still making trunk/main visible as the
 - **Bookmarks panel is the stack UX.** The jj log remains the commit graph; stack presentation and actions live in bookmarks.
 - **Dependent stacks by default.** A child PR targets the nearest ancestor bookmark; a stack root targets trunk.
 - **Standalone bookmarks stay standalone.** A bookmark that would target trunk is not shown as a stack unless it has stack children.
-- **Submit is local → GitHub.** Submit makes GitHub PR state match the local jj/bookmark stack.
-- **Sync is GitHub/trunk → local.** Sync reconciles local jj/bookmark state after remote or PR state changes.
+- **Sync is the single reconcile operation.** Sync makes the GitHub PR stack and local jj/bookmark stack match, creating/retargeting PRs and repairing local branches after remote or PR state changes.
+- **Merge is stack-aware.** Merge should land the stack root through the code host, then repair descendants so already-approved child PRs are not needlessly rewritten by an out-of-band merge/fetch flow.
 - **Fetch does not auto-sync.** If fetch reveals that local stacks may be stale, kajji should surface that sync is available, but sync remains an explicit user action.
 - **Dry-run first in UI.** Lowercase modal actions compute a plan and ask for confirmation; uppercase variants execute directly.
 - **CLI mirrors UI later.** Stack operations should eventually be available to agents via `kajji stack ...` commands, but the TUI flow is the priority.
@@ -167,10 +167,7 @@ main                                  #150  xsnpmwxy  feat(APN-572): add audio t
   ↳ audio-tracking-visuals            #152  szvuqomv  code cleanup for PR
     ↳ poc/demo-results-detail...            xyluqyrl  DEMO: transition
 
-s  stack submit --dry-run
-S  stack submit
-f  stack sync --dry-run
-F  stack sync
+s  stack sync
 
 Esc cancel
 ```
@@ -180,7 +177,7 @@ Notes:
 - Initial actions operate on the whole stack.
 - Do not show which child bookmark opened the modal unless an action specifically targets that bookmark.
 - Reuse bookmark row rendering where possible.
-- Include descriptions.
+- Omit descriptions in the modal to avoid horizontal overflow.
 - Include PR numbers when known.
 
 ## Standalone Bookmark Behavior
@@ -204,19 +201,15 @@ Rationale:
 Initial stack actions:
 
 ```text
-s  stack submit --dry-run
-S  stack submit
-f  stack sync --dry-run
-F  stack sync
+s  stack sync
 ```
 
-This mapping may be revisited after the flow settles. One possible future simplification is `s` for sync preview, `S` for submit preview, and a separate apply key from the preview/action modal. For now, keep the explicit four-action modal.
+`sync` opens a preview first; applying happens from the preview modal. Direct apply keybinds can be added later if needed, but they are not first-class in the initial UX.
 
 Do not include initially:
 
 - push stack
 - update comments/snippets
-- merge
 - doctor/status
 - undo
 
@@ -224,20 +217,20 @@ These may be added later if needed. Undo needs its own design because stack oper
 
 ### Why no push action initially?
 
-`push` and `submit` are easy to confuse:
+`push` is a lower-level implementation detail of sync:
 
 - Push bookmarks: update remote bookmark refs.
-- Submit stack: make GitHub PR state match the local jj/bookmark stack.
+- Sync stack: reconcile local jj bookmarks, remote bookmark refs, GitHub PR bases, and stack comments.
 
 Since kajji already has push flows, the stack modal should avoid this ambiguity initially.
 
 ### Why no comments/snippets action?
 
-Stack snippets are part of submit. Users should not need to run a separate "update comments" action.
+Stack snippets are part of sync. Users should not need to run a separate "update comments" action.
 
-## Submit
+## Sync
 
-`stack submit` is the local-to-GitHub operation.
+`stack sync` is the reconcile operation.
 
 Definition:
 
@@ -251,13 +244,13 @@ Responsibilities may include:
 - update stack snippets/comments/bodies
 - report conflicts or GitHub state mismatches
 
-`stack submit --dry-run` computes and displays the planned changes without applying them.
+`stack sync` first computes and displays the planned changes without applying them.
 
 ### UI behavior
 
 Lowercase `s`:
 
-1. Compute the submit plan.
+1. Compute the sync plan.
 2. Show a confirmation/plan modal.
 3. Apply only if the user confirms with `enter`.
 4. `esc` returns to the Stack Actions modal for the same stack.
@@ -268,7 +261,7 @@ The plan modal should reuse the same stack row rendering as the bookmarks panel 
 Example:
 
 ```text
-Submit preview for APN-607/deployment-ard-platform
+Sync preview for APN-607/deployment-ard-platform
 
 main                                  #150
 ↳ APN-607/deployment-ard-platform     #151  would retarget PR onto main
@@ -339,7 +332,7 @@ Rationale:
 - The snippet links to GitHub PRs by number.
 - GitHub's native links show whether PRs are open/merged/closed.
 - PR base/state is already visible in GitHub.
-- Snippets only need updating when submit adds or reshapes the PR stack.
+- Snippets only need updating when sync adds or reshapes the PR stack.
 
 This policy can be revisited later if we add explicit pruning/refresh behavior.
 
@@ -353,7 +346,7 @@ Lowercase `f`:
 4. `esc` returns to the Stack Actions modal for the same stack.
 5. Do not write the dry-run preview to the command log by default.
 
-The sync preview should use the same stack-connected modal style as submit, with concise per-row annotations.
+The sync preview should use the same stack-connected modal style as the stack actions modal, with concise per-row annotations.
 
 Example:
 
@@ -395,7 +388,7 @@ For kajji, the exact mechanism should be designed during implementation, but the
 
 - jj-local changes can lean on `jj op log` / `jj undo` where appropriate.
 - GitHub mutations need explicit before/after state recorded by kajji.
-- Applied `stack submit` / `stack sync` should record enough information to report what changed and what can be undone.
+- Applied `stack sync` should record enough information to report what changed and what can be undone.
 - Dry-run/plan previews do not need undo entries because they do not mutate state.
 
 Potential journal entries:
@@ -417,7 +410,7 @@ In the UI:
 - Actual executions are written to the command log.
 - Execution output should be streamed if possible.
 - Execution issues should be visible in the command log.
-- Do not use transient status-bar success/failure messages for completed stack submit/sync operations; the command log is the feedback surface for performed actions.
+- Do not use transient status-bar success/failure messages for completed stack sync operations; the command log is the feedback surface for performed actions.
 - Reserve transient status-bar messages for unavailable/no-op/lightweight feedback, such as `No stack for ...` or `Nothing to sync.`
 
 For CLI:
@@ -478,9 +471,6 @@ Initial command shape:
 
 ```bash
 kajji stack list
-kajji stack submit [bookmark] --dry-run
-kajji stack submit [bookmark]
-kajji stack sync [bookmark] --dry-run
 kajji stack sync [bookmark]
 ```
 
@@ -494,7 +484,7 @@ Rationale:
 
 - Stack operations combine jj/local mutations, GitHub mutations, dry-run planning, command streaming, and future undo journaling.
 - Failures need to be typed and surfaced with actionable recovery guidance.
-- Submit/sync should be testable with mocked jj and GitHub services, especially for partial failure and conflict scenarios.
+- Sync should be testable with mocked jj and GitHub services, especially for partial failure and conflict scenarios.
 - UI and CLI should share the same stack planner/interpreter rather than duplicating orchestration logic.
 
 The first production implementation should focus Effect usage on the stack core and adjacent command boundaries, not on rewriting the TUI.
@@ -504,12 +494,12 @@ Recommended service boundaries:
 - `Jj`: stack-relevant jj queries and mutations, including graph/bookmark state, `jj rebase -s`, operation ids, and undo-related queries.
 - `GitHub`: PR lookup/creation/update, base retargeting, body/comment snippet updates, and PR state reads.
 - `StackJournal`: durable operation journal for applied mutations and future undo support.
-- `StackPlanner`: pure or mostly pure discovery/planning for submit/sync dry-runs.
+- `StackPlanner`: pure or mostly pure discovery/planning for sync previews.
 - `StackExecutor`: apply-mode interpreter that executes a plan, streams/logs progress, and records journal entries.
 
 Initial Effect scope:
 
-- Build stack discovery, submit planning, sync planning, and apply-mode execution in an Effect subsystem.
+- Build stack discovery, sync planning, and apply-mode execution in an Effect subsystem.
 - Keep the Solid/OpenTUI UI mostly outside Effect; call into the stack runtime at modal/action boundaries.
 - Keep existing non-stack commander code unless it becomes a natural dependency of stack services.
 
@@ -543,7 +533,7 @@ Rationale:
 
 Before shipping, refine edge cases and presentation:
 
-- no-op plan messaging when submit/sync has nothing to do
+- no-op plan messaging when sync has nothing to do
 - stale or missing PR metadata handling
 - clearer conflict/error guidance for failed apply operations
 - stable modal layout when moving between actions and previews
@@ -578,7 +568,7 @@ When moving from PoC to production implementation, consider extracting stack dis
 Useful references:
 
 - `kitlangton/stack`: concise `sync` workflow, GitHub-native stack block, agent-friendly CLI shape.
-- Graphite: stack navigation snippets and submit/sync mental model.
+- Graphite: stack navigation snippets and stack operation mental model.
 - jj-native tools such as jj-ryu, jjpr, jj-stack, and jj-domino: validate bookmark-centric stacks for jj.
 
 This spec intentionally keeps only the decisions relevant to kajji's current direction rather than carrying forward all earlier research details.

--- a/docs/specs/github-stacking.md
+++ b/docs/specs/github-stacking.md
@@ -28,8 +28,9 @@ This keeps the hierarchy meaningful while still making trunk/main visible as the
 - **Standalone bookmarks stay standalone.** A bookmark that would target trunk is not shown as a stack unless it has stack children.
 - **Submit is local → GitHub.** Submit makes GitHub PR state match the local jj/bookmark stack.
 - **Sync is GitHub/trunk → local.** Sync reconciles local jj/bookmark state after remote or PR state changes.
+- **Fetch does not auto-sync.** If fetch reveals that local stacks may be stale, kajji should surface that sync is available, but sync remains an explicit user action.
 - **Dry-run first in UI.** Lowercase modal actions compute a plan and ask for confirmation; uppercase variants execute directly.
-- **CLI mirrors UI.** Stack operations should eventually be available to agents via `kajji stack ...` commands.
+- **CLI mirrors UI later.** Stack operations should eventually be available to agents via `kajji stack ...` commands, but the TUI flow is the priority.
 
 ## Definitions
 
@@ -209,6 +210,8 @@ f  stack sync --dry-run
 F  stack sync
 ```
 
+This mapping may be revisited after the flow settles. One possible future simplification is `s` for sync preview, `S` for submit preview, and a separate apply key from the preview/action modal. For now, keep the explicit four-action modal.
+
 Do not include initially:
 
 - push stack
@@ -256,8 +259,26 @@ Lowercase `s`:
 
 1. Compute the submit plan.
 2. Show a confirmation/plan modal.
-3. Apply only if the user confirms.
-4. Do not write the dry-run preview to the command log by default.
+3. Apply only if the user confirms with `enter`.
+4. `esc` returns to the Stack Actions modal for the same stack.
+5. Do not write the dry-run preview to the command log by default.
+
+The plan modal should reuse the same stack row rendering as the bookmarks panel and Stack Actions modal. It should annotate rows with concise evaluated actions rather than showing a detached implementation checklist.
+
+Example:
+
+```text
+Submit preview for APN-607/deployment-ard-platform
+
+main                                  #150
+↳ APN-607/deployment-ard-platform     #151  would retarget PR onto main
+  ↳ audio-tracking-visuals            #152  would create PR onto APN-607/deployment-ard-platform
+
+Would update PRs: #151
+Would create PRs: audio-tracking-visuals
+
+enter apply   esc back
+```
 
 Uppercase `S`:
 
@@ -282,6 +303,18 @@ Likely responsibilities:
 - plan local rebase/cleanup work when parent PRs have landed
 - retarget remaining PR bases if required
 - report conflicts or GitHub state mismatches
+
+### Fetch and stale stacks
+
+`jj git fetch` can change trunk/remotes in ways that make local stack state stale, especially after a PR in a stack has merged. Fetch itself should not automatically run stack sync, because sync mutates local history with rebases.
+
+Instead, kajji should detect when fetched state may affect local stacks and surface a lightweight prompt/indicator that sync is available. The exact UX is not decided yet. Possible directions:
+
+- transient status-bar prompt, e.g. `Stack sync available`
+- command-log info with a direct sync action
+- stack-modal annotation on affected stacks
+
+If affected stacks can be detected reliably, prefer syncing only those stacks. Otherwise, offer an explicit sync-all-local-stacks flow with a dry-run preview first.
 
 `stack sync --dry-run` computes and displays the planned changes without applying them.
 
@@ -316,8 +349,25 @@ Lowercase `f`:
 
 1. Compute the sync plan.
 2. Show a confirmation/plan modal.
-3. Apply only if the user confirms.
-4. Do not write the dry-run preview to the command log by default.
+3. Apply only if the user confirms with `enter`.
+4. `esc` returns to the Stack Actions modal for the same stack.
+5. Do not write the dry-run preview to the command log by default.
+
+The sync preview should use the same stack-connected modal style as submit, with concise per-row annotations.
+
+Example:
+
+```text
+Sync preview for APN-607/deployment-ard-platform
+
+main                                  #150
+↳ APN-607/deployment-ard-platform     #151  targets main
+  ↳ audio-tracking-visuals            #152  would rebase onto APN-607/deployment-ard-platform
+
+Would rebase: audio-tracking-visuals
+
+enter apply   esc back
+```
 
 Uppercase `F`:
 
@@ -367,6 +417,8 @@ In the UI:
 - Actual executions are written to the command log.
 - Execution output should be streamed if possible.
 - Execution issues should be visible in the command log.
+- Do not use transient status-bar success/failure messages for completed stack submit/sync operations; the command log is the feedback surface for performed actions.
+- Reserve transient status-bar messages for unavailable/no-op/lightweight feedback, such as `No stack for ...` or `Nothing to sync.`
 
 For CLI:
 
@@ -375,25 +427,30 @@ For CLI:
 
 ## Stack Snippet Format
 
-A compact GitHub-native stack snippet is preferred.
+Use a managed PR comment, not the PR body. The comment should be compact and GitHub-native.
 
-Example:
+Example on PR `#102`:
 
 ```markdown
+<!-- kajji-stack pr=102 -->
+
 ### Stack
 
 1. #101
-2. **#102** 👈 current
+2. #102 👈
+3. #103
+
+This stack is managed by [kajji](https://github.com/eliaskc/kajji).
 ```
 
 Notes:
 
 - GitHub automatically links PR numbers.
-- The current PR is emphasized.
+- The current PR is marked with `👈` after its PR number.
+- Do not include bookmark names in the stack comment.
 - The snippet does not need to show PR base, state, checks, or review status.
 - Those are native GitHub concepts visible on the PRs themselves.
-
-Implementation can choose PR body blocks or marker comments. Earlier exploration favored comments; `kitlangton/stack` shows body blocks can also work well.
+- The marker identifies the PR whose comment is being managed so kajji can find/update the right comment safely.
 
 ## PR Numbers in Kajji
 
@@ -415,7 +472,7 @@ Rules:
 
 ## CLI Mirror
 
-Kajji should eventually expose stack operations in the CLI so agents can perform them.
+Kajji should eventually expose stack operations in the CLI so agents can perform them. This is lower priority than completing the TUI stack flow.
 
 Initial command shape:
 
@@ -462,6 +519,36 @@ Potential next steps after stack lands:
 - Migrate jj command wrappers used by stack into Effect services first, then consider broader commander migration.
 - Migrate GitHub PR helpers used by stack into typed Effect services.
 - Reuse the same services for the future `kajji stack ...` CLI mirror.
+
+## Durable Stack Journal
+
+Stack operation journals should be stored in kajji-owned global cache state, not in the repository worktree. Prefer `~/.cache/kajji/...` on Unix-like systems, with platform-appropriate fallbacks later if needed.
+
+The journal path should include a stable repo key, for example a hash of the repository root path, to avoid collisions:
+
+```text
+~/.cache/kajji/stack-journal/<repo-key>/<journal-id>.json
+```
+
+Rationale:
+
+- Do not create project worktree files for kajji internals.
+- Keep operation/undo metadata app-owned.
+- Avoid requiring users to add project-specific ignores.
+- Make future cleanup/inspection of kajji state straightforward.
+
+`kitlangton/stack` stores state under Git metadata (`.git/stack/...`), which similarly avoids touching the worktree. For kajji, a global cache is preferred.
+
+## Polish / Follow-up
+
+Before shipping, refine edge cases and presentation:
+
+- no-op plan messaging when submit/sync has nothing to do
+- stale or missing PR metadata handling
+- clearer conflict/error guidance for failed apply operations
+- stable modal layout when moving between actions and previews
+- consistent stack row rendering across bookmarks, actions, picker, and previews
+- exact wording for row annotations such as `targets main`, `would retarget PR onto ...`, and `would rebase onto ...`
 
 Avoid a broad UI rewrite as part of adopting Effect. The valuable migration boundary is command orchestration, error handling, streaming, and testability.
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
         "babel-preset-solid": "1.9.12",
         "citty": "^0.2.0",
         "diff": "^8.0.2",
+        "effect": "4.0.0-beta.65",
         "fuzzysort": "^3.1.0",
         "ghostty-opentui": "^1.4.12",
         "jsonc-parser": "^3.3.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -271,7 +271,7 @@ function AppContent() {
                 mutedPrefix: "jj git fetch ",
                 label: "--branch glob:push-*",
                 onSelect: () =>
-                    void runGitFetch("Fetching stack branches...", {
+                    void runGitFetch("Fetching push branches...", {
                         branches: ["glob:push-*"],
                     }),
             },

--- a/src/commander/github.ts
+++ b/src/commander/github.ts
@@ -72,10 +72,12 @@ export interface GitHubPullRequestSummary {
     createdAt?: string
 }
 
-export function parseGhRepositoryJson(stdout: string): {
+export interface GitHubRepository {
     owner: string
     name: string
-} {
+}
+
+export function parseGhRepositoryJson(stdout: string): GitHubRepository {
     const value = JSON.parse(stdout) as unknown
     if (!value || typeof value !== "object") {
         throw new Error("Invalid gh repo view response")
@@ -90,6 +92,19 @@ export function parseGhRepositoryJson(stdout: string): {
         throw new Error("Invalid gh repo view response")
     }
     return { owner: ownerLogin, name: record.name }
+}
+
+export function parseGitHubRemoteUrl(
+    url: string,
+): GitHubRepository | undefined {
+    const trimmed = url.trim()
+    const match = trimmed.match(
+        /^(?:https:\/\/github\.com\/|git@github\.com:)([^/]+)\/([^/]+?)(?:\.git)?$/,
+    )
+    const owner = match?.[1]
+    const name = match?.[2]
+    if (!owner || !name) return undefined
+    return { owner, name }
 }
 
 export function parseGhPullRequestsByHeadGraphqlJson(
@@ -181,6 +196,40 @@ function preferPullRequest(
     return candidate.number > existing.number
 }
 
+async function gitOutput(args: readonly string[]): Promise<string | undefined> {
+    const proc = Bun.spawn(["git", ...args], {
+        cwd: getRepoPath(),
+        stdin: "ignore",
+        stdout: "pipe",
+        stderr: "pipe",
+    })
+    const [stdout, exitCode] = await Promise.all([
+        new Response(proc.stdout as ReadableStream<Uint8Array>).text(),
+        proc.exited,
+    ])
+    if (exitCode !== 0) return undefined
+    return stdout.trim()
+}
+
+async function resolveGitHubRepository(): Promise<GitHubRepository> {
+    const originUrl = await gitOutput(["remote", "get-url", "origin"])
+    const originRepo = originUrl ? parseGitHubRemoteUrl(originUrl) : undefined
+    if (originRepo) return originRepo
+
+    return parseGhRepositoryJson(
+        await ghOutput(["repo", "view", "--json", "owner,name"]),
+    )
+}
+
+function repoFullName(repo: GitHubRepository): string {
+    return `${repo.owner}/${repo.name}`
+}
+
+async function withResolvedRepo(args: readonly string[]): Promise<string[]> {
+    const repo = await resolveGitHubRepository()
+    return [...args, "--repo", repoFullName(repo)]
+}
+
 async function ghOutput(
     args: readonly string[],
     stdin?: string,
@@ -211,9 +260,7 @@ export async function ghListPullRequestsByHead(
     const uniqueHeads = [...new Set(heads)].filter(Boolean)
     if (uniqueHeads.length === 0) return new Map()
 
-    const repo = parseGhRepositoryJson(
-        await ghOutput(["repo", "view", "--json", "owner,name"]),
-    )
+    const repo = await resolveGitHubRepository()
     const states = options.includeClosed ? "[OPEN, CLOSED, MERGED]" : "OPEN"
     const query = `query PullRequestsByHead($owner: String!, $name: String!) {
   repository(owner: $owner, name: $name) {
@@ -377,7 +424,15 @@ export async function ghPrCreate(
     options?: OperationRunOptions,
 ): Promise<OperationResult> {
     return ghOperation(
-        ["pr", "create", "--head", input.head, "--base", input.base, "--fill"],
+        await withResolvedRepo([
+            "pr",
+            "create",
+            "--head",
+            input.head,
+            "--base",
+            input.base,
+            "--fill",
+        ]),
         options,
     )
 }
@@ -388,7 +443,13 @@ export async function ghPrEditBase(
     options?: OperationRunOptions,
 ): Promise<OperationResult> {
     return ghOperation(
-        ["pr", "edit", String(prNumber), "--base", base],
+        await withResolvedRepo([
+            "pr",
+            "edit",
+            String(prNumber),
+            "--base",
+            base,
+        ]),
         options,
     )
 }
@@ -397,14 +458,20 @@ export async function ghPrClose(
     prNumber: number,
     options?: OperationRunOptions,
 ): Promise<OperationResult> {
-    return ghOperation(["pr", "close", String(prNumber)], options)
+    return ghOperation(
+        await withResolvedRepo(["pr", "close", String(prNumber)]),
+        options,
+    )
 }
 
 export async function ghPrViewWeb(
     prNumber: number,
     options?: OperationRunOptions,
 ): Promise<OperationResult> {
-    return ghOperation(["pr", "view", String(prNumber), "--web"], options)
+    return ghOperation(
+        await withResolvedRepo(["pr", "view", String(prNumber), "--web"]),
+        options,
+    )
 }
 
 export async function ghUpsertStackComment(
@@ -412,9 +479,7 @@ export async function ghUpsertStackComment(
     body: string,
     options?: OperationRunOptions,
 ): Promise<OperationResult> {
-    const repo = parseGhRepositoryJson(
-        await ghOutput(["repo", "view", "--json", "owner,name"]),
-    )
+    const repo = await resolveGitHubRepository()
     const marker = `<!-- kajji-stack pr=${prNumber} -->`
     const commentsJson = await ghOutput([
         "api",

--- a/src/commander/github.ts
+++ b/src/commander/github.ts
@@ -116,17 +116,14 @@ function parseGhPullRequestsByHeadGraphqlJsonInternal(
     if (!repository || typeof repository !== "object") return new Map()
 
     const pulls = new Map<string, GitHubPullRequestSummary>()
-    for (const ref of Object.values(repository as Record<string, unknown>)) {
-        if (!ref || typeof ref !== "object") continue
-        const associatedPullRequests = (ref as Record<string, unknown>)
-            .associatedPullRequests
-        if (
-            !associatedPullRequests ||
-            typeof associatedPullRequests !== "object"
-        ) {
-            continue
-        }
-        const nodes = (associatedPullRequests as Record<string, unknown>).nodes
+    for (const connection of Object.values(
+        repository as Record<string, unknown>,
+    )) {
+        if (!connection || typeof connection !== "object") continue
+        const record = connection as Record<string, unknown>
+        const pullConnection = record.associatedPullRequests ?? connection
+        if (!pullConnection || typeof pullConnection !== "object") continue
+        const nodes = (pullConnection as Record<string, unknown>).nodes
         if (!Array.isArray(nodes)) continue
         for (const node of nodes) {
             if (!node || typeof node !== "object") continue
@@ -172,10 +169,6 @@ function preferPullRequest(
     candidate: GitHubPullRequestSummary,
     existing: GitHubPullRequestSummary,
 ): boolean {
-    if (candidate.state === "OPEN" && existing.state !== "OPEN") return true
-    if (candidate.state !== "OPEN" && existing.state === "OPEN") return false
-    if (candidate.merged === true && existing.merged !== true) return true
-    if (candidate.merged !== true && existing.merged === true) return false
     const candidateTime = Date.parse(
         candidate.updatedAt ?? candidate.createdAt ?? "",
     )
@@ -229,7 +222,10 @@ ${uniqueHeads
         (head, index) =>
             `    h${index}: ref(qualifiedName: ${JSON.stringify(
                 `refs/heads/${head}`,
-            )}) { associatedPullRequests(first: 20, states: ${states}) { nodes { number headRefName baseRefName state merged updatedAt createdAt } } }`,
+            )}) { associatedPullRequests(first: 20, states: ${states}) { nodes { number headRefName baseRefName state merged updatedAt createdAt } } }
+    p${index}: pullRequests(first: 20, states: ${states}, headRefName: ${JSON.stringify(
+        head,
+    )}) { nodes { number headRefName baseRefName state merged updatedAt createdAt } }`,
     )
     .join("\n")}
   }

--- a/src/commander/github.ts
+++ b/src/commander/github.ts
@@ -65,6 +65,7 @@ function finishObservedGhCommand(
 export interface GitHubPullRequestSummary {
     number: number
     headRefName: string
+    baseRefName?: string
 }
 
 export function parseGhRepositoryJson(stdout: string): {
@@ -118,6 +119,9 @@ export function parseGhPullRequestsByHeadGraphqlJson(
             pulls.set(record.headRefName, {
                 number: record.number,
                 headRefName: record.headRefName,
+                ...(typeof record.baseRefName === "string"
+                    ? { baseRefName: record.baseRefName }
+                    : {}),
             })
         }
     }
@@ -163,7 +167,7 @@ ${uniqueHeads
         (head, index) =>
             `    h${index}: ref(qualifiedName: ${JSON.stringify(
                 `refs/heads/${head}`,
-            )}) { associatedPullRequests(first: 1) { nodes { number headRefName } } }`,
+            )}) { associatedPullRequests(first: 1) { nodes { number headRefName baseRefName } } }`,
     )
     .join("\n")}
   }

--- a/src/commander/github.ts
+++ b/src/commander/github.ts
@@ -68,6 +68,8 @@ export interface GitHubPullRequestSummary {
     baseRefName?: string
     state?: string
     merged?: boolean
+    updatedAt?: string
+    createdAt?: string
 }
 
 export function parseGhRepositoryJson(stdout: string): {
@@ -138,7 +140,7 @@ function parseGhPullRequestsByHeadGraphqlJsonInternal(
             ) {
                 continue
             }
-            pulls.set(record.headRefName, {
+            const summary = {
                 number: record.number,
                 headRefName: record.headRefName,
                 ...(typeof record.baseRefName === "string"
@@ -150,10 +152,40 @@ function parseGhPullRequestsByHeadGraphqlJsonInternal(
                 ...(typeof record.merged === "boolean"
                     ? { merged: record.merged }
                     : {}),
-            })
+                ...(typeof record.updatedAt === "string"
+                    ? { updatedAt: record.updatedAt }
+                    : {}),
+                ...(typeof record.createdAt === "string"
+                    ? { createdAt: record.createdAt }
+                    : {}),
+            } satisfies GitHubPullRequestSummary
+            const existing = pulls.get(record.headRefName)
+            if (!existing || preferPullRequest(summary, existing)) {
+                pulls.set(record.headRefName, summary)
+            }
         }
     }
     return pulls
+}
+
+function preferPullRequest(
+    candidate: GitHubPullRequestSummary,
+    existing: GitHubPullRequestSummary,
+): boolean {
+    if (candidate.state === "OPEN" && existing.state !== "OPEN") return true
+    if (candidate.state !== "OPEN" && existing.state === "OPEN") return false
+    if (candidate.merged === true && existing.merged !== true) return true
+    if (candidate.merged !== true && existing.merged === true) return false
+    const candidateTime = Date.parse(
+        candidate.updatedAt ?? candidate.createdAt ?? "",
+    )
+    const existingTime = Date.parse(
+        existing.updatedAt ?? existing.createdAt ?? "",
+    )
+    if (!Number.isNaN(candidateTime) && !Number.isNaN(existingTime)) {
+        return candidateTime > existingTime
+    }
+    return candidate.number > existing.number
 }
 
 async function ghOutput(
@@ -189,7 +221,7 @@ export async function ghListPullRequestsByHead(
     const repo = parseGhRepositoryJson(
         await ghOutput(["repo", "view", "--json", "owner,name"]),
     )
-    const states = options.includeClosed ? "[OPEN, CLOSED]" : "OPEN"
+    const states = options.includeClosed ? "[OPEN, CLOSED, MERGED]" : "OPEN"
     const query = `query PullRequestsByHead($owner: String!, $name: String!) {
   repository(owner: $owner, name: $name) {
 ${uniqueHeads
@@ -197,7 +229,7 @@ ${uniqueHeads
         (head, index) =>
             `    h${index}: ref(qualifiedName: ${JSON.stringify(
                 `refs/heads/${head}`,
-            )}) { associatedPullRequests(first: 1, states: ${states}) { nodes { number headRefName baseRefName state merged } } }`,
+            )}) { associatedPullRequests(first: 20, states: ${states}) { nodes { number headRefName baseRefName state merged updatedAt createdAt } } }`,
     )
     .join("\n")}
   }
@@ -422,6 +454,7 @@ export async function ghUpsertStackComment(
         return ghOperation(
             [
                 "api",
+                "--silent",
                 "--method",
                 "PATCH",
                 `repos/${repo.owner}/${repo.name}/issues/comments/${existingId}`,
@@ -434,6 +467,7 @@ export async function ghUpsertStackComment(
     return ghOperation(
         [
             "api",
+            "--silent",
             "--method",
             "POST",
             `repos/${repo.owner}/${repo.name}/issues/${prNumber}/comments`,

--- a/src/commander/github.ts
+++ b/src/commander/github.ts
@@ -373,22 +373,11 @@ async function ghOperation(
 }
 
 export async function ghPrCreate(
-    input: { head: string; base: string; title: string; body?: string },
+    input: { head: string; base: string },
     options?: OperationRunOptions,
 ): Promise<OperationResult> {
     return ghOperation(
-        [
-            "pr",
-            "create",
-            "--head",
-            input.head,
-            "--base",
-            input.base,
-            "--title",
-            input.title,
-            "--body",
-            input.body ?? "",
-        ],
+        ["pr", "create", "--head", input.head, "--base", input.base, "--fill"],
         options,
     )
 }

--- a/src/commander/github.ts
+++ b/src/commander/github.ts
@@ -67,6 +67,7 @@ export interface GitHubPullRequestSummary {
     headRefName: string
     baseRefName?: string
     state?: string
+    merged?: boolean
 }
 
 export function parseGhRepositoryJson(stdout: string): {
@@ -91,6 +92,19 @@ export function parseGhRepositoryJson(stdout: string): {
 
 export function parseGhPullRequestsByHeadGraphqlJson(
     stdout: string,
+): Map<string, GitHubPullRequestSummary> {
+    return parseGhPullRequestsByHeadGraphqlJsonInternal(stdout, false)
+}
+
+export function parseGhPullRequestsByHeadGraphqlJsonIncludingClosed(
+    stdout: string,
+): Map<string, GitHubPullRequestSummary> {
+    return parseGhPullRequestsByHeadGraphqlJsonInternal(stdout, true)
+}
+
+function parseGhPullRequestsByHeadGraphqlJsonInternal(
+    stdout: string,
+    includeClosed: boolean,
 ): Map<string, GitHubPullRequestSummary> {
     const value = JSON.parse(stdout) as unknown
     if (!value || typeof value !== "object") return new Map()
@@ -117,7 +131,11 @@ export function parseGhPullRequestsByHeadGraphqlJson(
             const record = node as Record<string, unknown>
             if (typeof record.number !== "number") continue
             if (typeof record.headRefName !== "string") continue
-            if (typeof record.state === "string" && record.state !== "OPEN") {
+            if (
+                !includeClosed &&
+                typeof record.state === "string" &&
+                record.state !== "OPEN"
+            ) {
                 continue
             }
             pulls.set(record.headRefName, {
@@ -128,6 +146,9 @@ export function parseGhPullRequestsByHeadGraphqlJson(
                     : {}),
                 ...(typeof record.state === "string"
                     ? { state: record.state }
+                    : {}),
+                ...(typeof record.merged === "boolean"
+                    ? { merged: record.merged }
                     : {}),
             })
         }
@@ -160,6 +181,7 @@ async function ghOutput(
 
 export async function ghListPullRequestsByHead(
     heads: readonly string[] = [],
+    options: { includeClosed?: boolean } = {},
 ): Promise<Map<string, GitHubPullRequestSummary>> {
     const uniqueHeads = [...new Set(heads)].filter(Boolean)
     if (uniqueHeads.length === 0) return new Map()
@@ -167,6 +189,7 @@ export async function ghListPullRequestsByHead(
     const repo = parseGhRepositoryJson(
         await ghOutput(["repo", "view", "--json", "owner,name"]),
     )
+    const states = options.includeClosed ? "[OPEN, CLOSED]" : "OPEN"
     const query = `query PullRequestsByHead($owner: String!, $name: String!) {
   repository(owner: $owner, name: $name) {
 ${uniqueHeads
@@ -174,7 +197,7 @@ ${uniqueHeads
         (head, index) =>
             `    h${index}: ref(qualifiedName: ${JSON.stringify(
                 `refs/heads/${head}`,
-            )}) { associatedPullRequests(first: 1, states: OPEN) { nodes { number headRefName baseRefName state } } }`,
+            )}) { associatedPullRequests(first: 1, states: ${states}) { nodes { number headRefName baseRefName state merged } } }`,
     )
     .join("\n")}
   }
@@ -189,7 +212,9 @@ ${uniqueHeads
         "-f",
         `query=${query}`,
     ])
-    return parseGhPullRequestsByHeadGraphqlJson(stdout)
+    return options.includeClosed
+        ? parseGhPullRequestsByHeadGraphqlJsonIncludingClosed(stdout)
+        : parseGhPullRequestsByHeadGraphqlJson(stdout)
 }
 
 export async function ghPrCreateWeb(
@@ -274,4 +299,147 @@ export async function ghBrowseCommit(
             command,
         }
     }
+}
+
+async function ghOperation(
+    args: readonly string[],
+    options?: OperationRunOptions & { stdin?: string; command?: string },
+): Promise<OperationResult> {
+    const command = options?.command ?? `gh ${args.join(" ")}`
+    try {
+        const proc = Bun.spawn(["gh", ...args], {
+            cwd: getRepoPath(),
+            stdin: options?.stdin === undefined ? "ignore" : "pipe",
+            stdout: "pipe",
+            stderr: "pipe",
+        })
+        if (options?.stdin !== undefined && proc.stdin) {
+            proc.stdin.write(options.stdin)
+            proc.stdin.end()
+        }
+        const { stdout, stderr, logId } = await readGhOutput(
+            command,
+            proc,
+            options?.observer,
+        )
+        const exitCode = await proc.exited
+        const result = {
+            stdout,
+            stderr,
+            exitCode,
+            success: exitCode === 0,
+            command,
+            logged: Boolean(logId),
+        }
+        finishObservedGhCommand(options?.observer, logId, result)
+        return result
+    } catch (error) {
+        return {
+            stdout: "",
+            stderr: error instanceof Error ? error.message : String(error),
+            exitCode: 1,
+            success: false,
+            command,
+        }
+    }
+}
+
+export async function ghPrCreate(
+    input: { head: string; base: string; title: string; body?: string },
+    options?: OperationRunOptions,
+): Promise<OperationResult> {
+    return ghOperation(
+        [
+            "pr",
+            "create",
+            "--head",
+            input.head,
+            "--base",
+            input.base,
+            "--title",
+            input.title,
+            "--body",
+            input.body ?? "",
+        ],
+        options,
+    )
+}
+
+export async function ghPrEditBase(
+    prNumber: number,
+    base: string,
+    options?: OperationRunOptions,
+): Promise<OperationResult> {
+    return ghOperation(
+        ["pr", "edit", String(prNumber), "--base", base],
+        options,
+    )
+}
+
+export async function ghPrClose(
+    prNumber: number,
+    options?: OperationRunOptions,
+): Promise<OperationResult> {
+    return ghOperation(["pr", "close", String(prNumber)], options)
+}
+
+export async function ghPrViewWeb(
+    prNumber: number,
+    options?: OperationRunOptions,
+): Promise<OperationResult> {
+    return ghOperation(["pr", "view", String(prNumber), "--web"], options)
+}
+
+export async function ghUpsertStackComment(
+    prNumber: number,
+    body: string,
+    options?: OperationRunOptions,
+): Promise<OperationResult> {
+    const repo = parseGhRepositoryJson(
+        await ghOutput(["repo", "view", "--json", "owner,name"]),
+    )
+    const marker = `<!-- kajji-stack pr=${prNumber} -->`
+    const commentsJson = await ghOutput([
+        "api",
+        `repos/${repo.owner}/${repo.name}/issues/${prNumber}/comments`,
+    ])
+    const comments = JSON.parse(commentsJson) as unknown
+    const existing = Array.isArray(comments)
+        ? comments.find((comment) => {
+              if (!comment || typeof comment !== "object") return false
+              const record = comment as Record<string, unknown>
+              return (
+                  typeof record.body === "string" &&
+                  record.body.includes(marker)
+              )
+          })
+        : undefined
+    const existingId =
+        existing && typeof existing === "object"
+            ? (existing as Record<string, unknown>).id
+            : undefined
+    if (typeof existingId === "number") {
+        return ghOperation(
+            [
+                "api",
+                "--method",
+                "PATCH",
+                `repos/${repo.owner}/${repo.name}/issues/comments/${existingId}`,
+                "-f",
+                `body=${body}`,
+            ],
+            options,
+        )
+    }
+    return ghOperation(
+        [
+            "api",
+            "--method",
+            "POST",
+            `repos/${repo.owner}/${repo.name}/issues/${prNumber}/comments`,
+            "-f",
+            `body=${body}`,
+        ],
+        options,
+    )
 }

--- a/src/commander/github.ts
+++ b/src/commander/github.ts
@@ -62,6 +62,125 @@ function finishObservedGhCommand(
     if (logId) observer?.finish(logId, result)
 }
 
+export interface GitHubPullRequestSummary {
+    number: number
+    headRefName: string
+}
+
+export function parseGhRepositoryJson(stdout: string): {
+    owner: string
+    name: string
+} {
+    const value = JSON.parse(stdout) as unknown
+    if (!value || typeof value !== "object") {
+        throw new Error("Invalid gh repo view response")
+    }
+    const record = value as Record<string, unknown>
+    const owner = record.owner
+    if (!owner || typeof owner !== "object") {
+        throw new Error("Invalid gh repo owner response")
+    }
+    const ownerLogin = (owner as Record<string, unknown>).login
+    if (typeof ownerLogin !== "string" || typeof record.name !== "string") {
+        throw new Error("Invalid gh repo view response")
+    }
+    return { owner: ownerLogin, name: record.name }
+}
+
+export function parseGhPullRequestsByHeadGraphqlJson(
+    stdout: string,
+): Map<string, GitHubPullRequestSummary> {
+    const value = JSON.parse(stdout) as unknown
+    if (!value || typeof value !== "object") return new Map()
+    const data = (value as Record<string, unknown>).data
+    if (!data || typeof data !== "object") return new Map()
+    const repository = (data as Record<string, unknown>).repository
+    if (!repository || typeof repository !== "object") return new Map()
+
+    const pulls = new Map<string, GitHubPullRequestSummary>()
+    for (const ref of Object.values(repository as Record<string, unknown>)) {
+        if (!ref || typeof ref !== "object") continue
+        const associatedPullRequests = (ref as Record<string, unknown>)
+            .associatedPullRequests
+        if (
+            !associatedPullRequests ||
+            typeof associatedPullRequests !== "object"
+        ) {
+            continue
+        }
+        const nodes = (associatedPullRequests as Record<string, unknown>).nodes
+        if (!Array.isArray(nodes)) continue
+        for (const node of nodes) {
+            if (!node || typeof node !== "object") continue
+            const record = node as Record<string, unknown>
+            if (typeof record.number !== "number") continue
+            if (typeof record.headRefName !== "string") continue
+            pulls.set(record.headRefName, {
+                number: record.number,
+                headRefName: record.headRefName,
+            })
+        }
+    }
+    return pulls
+}
+
+async function ghOutput(
+    args: readonly string[],
+    stdin?: string,
+): Promise<string> {
+    const proc = Bun.spawn(["gh", ...args], {
+        cwd: getRepoPath(),
+        stdin: stdin === undefined ? "ignore" : "pipe",
+        stdout: "pipe",
+        stderr: "pipe",
+    })
+    if (stdin !== undefined && proc.stdin) {
+        proc.stdin.write(stdin)
+        proc.stdin.end()
+    }
+    const [stdout, stderr, exitCode] = await Promise.all([
+        new Response(proc.stdout as ReadableStream<Uint8Array>).text(),
+        new Response(proc.stderr as ReadableStream<Uint8Array>).text(),
+        proc.exited,
+    ])
+    if (exitCode !== 0) throw new Error(stderr || stdout || "gh command failed")
+    return stdout
+}
+
+export async function ghListPullRequestsByHead(
+    heads: readonly string[] = [],
+): Promise<Map<string, GitHubPullRequestSummary>> {
+    const uniqueHeads = [...new Set(heads)].filter(Boolean)
+    if (uniqueHeads.length === 0) return new Map()
+
+    const repo = parseGhRepositoryJson(
+        await ghOutput(["repo", "view", "--json", "owner,name"]),
+    )
+    const query = `query PullRequestsByHead($owner: String!, $name: String!) {
+  repository(owner: $owner, name: $name) {
+${uniqueHeads
+    .map(
+        (head, index) =>
+            `    h${index}: ref(qualifiedName: ${JSON.stringify(
+                `refs/heads/${head}`,
+            )}) { associatedPullRequests(first: 1) { nodes { number headRefName } } }`,
+    )
+    .join("\n")}
+  }
+}`
+    const stdout = await ghOutput([
+        "api",
+        "graphql",
+        "-f",
+        `owner=${repo.owner}`,
+        "-f",
+        `name=${repo.name}`,
+        "-f",
+        `query=${query}`,
+    ])
+    return parseGhPullRequestsByHeadGraphqlJson(stdout)
+}
+
 export async function ghPrCreateWeb(
     head: string,
     options?: OperationRunOptions,

--- a/src/commander/github.ts
+++ b/src/commander/github.ts
@@ -66,6 +66,7 @@ export interface GitHubPullRequestSummary {
     number: number
     headRefName: string
     baseRefName?: string
+    state?: string
 }
 
 export function parseGhRepositoryJson(stdout: string): {
@@ -116,11 +117,17 @@ export function parseGhPullRequestsByHeadGraphqlJson(
             const record = node as Record<string, unknown>
             if (typeof record.number !== "number") continue
             if (typeof record.headRefName !== "string") continue
+            if (typeof record.state === "string" && record.state !== "OPEN") {
+                continue
+            }
             pulls.set(record.headRefName, {
                 number: record.number,
                 headRefName: record.headRefName,
                 ...(typeof record.baseRefName === "string"
                     ? { baseRefName: record.baseRefName }
+                    : {}),
+                ...(typeof record.state === "string"
+                    ? { state: record.state }
                     : {}),
             })
         }
@@ -167,7 +174,7 @@ ${uniqueHeads
         (head, index) =>
             `    h${index}: ref(qualifiedName: ${JSON.stringify(
                 `refs/heads/${head}`,
-            )}) { associatedPullRequests(first: 1) { nodes { number headRefName baseRefName } } }`,
+            )}) { associatedPullRequests(first: 1, states: OPEN) { nodes { number headRefName baseRefName state } } }`,
     )
     .join("\n")}
   }

--- a/src/commander/log.ts
+++ b/src/commander/log.ts
@@ -16,6 +16,8 @@ function buildTemplate(): string {
         `"${MARKER}"`,
         "commit_id",
         `"${MARKER}"`,
+        'parents.map(|c| c.commit_id()).join(",")',
+        `"${MARKER}"`,
         "immutable",
         `"${MARKER}"`,
         "empty",
@@ -54,26 +56,42 @@ export function parseLogOutput(output: string): Commit[] {
                 }
 
                 const gutter = parts[0] ?? ""
-                const bookmarksRaw = stripAnsi(parts[10] ?? "")
-                const workingCopiesRaw = stripAnsi(parts[12] ?? "")
+                const hasParentIds = parts.length >= 15
+                const parentCommitIdsRaw = hasParentIds
+                    ? stripAnsi(parts[3] ?? "")
+                    : ""
+                const bookmarksRaw = stripAnsi(
+                    parts[hasParentIds ? 11 : 10] ?? "",
+                )
+                const workingCopiesRaw = stripAnsi(
+                    parts[hasParentIds ? 13 : 12] ?? "",
+                )
                 current = {
                     changeId: stripAnsi(parts[1] ?? ""),
                     commitId: stripAnsi(parts[2] ?? ""),
-                    immutable: stripAnsi(parts[3] ?? "") === "true",
-                    empty: stripAnsi(parts[4] ?? "") === "true",
-                    divergent: stripAnsi(parts[5] ?? "") === "true",
-                    description: stripAnsi(parts[6] ?? ""),
-                    author: stripAnsi(parts[7] ?? ""),
-                    authorEmail: stripAnsi(parts[8] ?? ""),
-                    timestamp: stripAnsi(parts[9] ?? ""),
+                    parentCommitIds: parentCommitIdsRaw
+                        ? parentCommitIdsRaw.split(",")
+                        : [],
+                    immutable:
+                        stripAnsi(parts[hasParentIds ? 4 : 3] ?? "") === "true",
+                    empty:
+                        stripAnsi(parts[hasParentIds ? 5 : 4] ?? "") === "true",
+                    divergent:
+                        stripAnsi(parts[hasParentIds ? 6 : 5] ?? "") === "true",
+                    description: stripAnsi(parts[hasParentIds ? 7 : 6] ?? ""),
+                    author: stripAnsi(parts[hasParentIds ? 8 : 7] ?? ""),
+                    authorEmail: stripAnsi(parts[hasParentIds ? 9 : 8] ?? ""),
+                    timestamp: stripAnsi(parts[hasParentIds ? 10 : 9] ?? ""),
                     bookmarks: bookmarksRaw ? bookmarksRaw.split(",") : [],
-                    gitHead: stripAnsi(parts[11] ?? "") === "true",
+                    gitHead:
+                        stripAnsi(parts[hasParentIds ? 12 : 11] ?? "") ===
+                        "true",
                     workingCopies: workingCopiesRaw
                         ? workingCopiesRaw.split(",")
                         : [],
                     isWorkingCopy: gutter.includes("@"),
-                    refLine: parts[13] ?? "",
-                    lines: [gutter + (parts[13] ?? "")],
+                    refLine: parts[hasParentIds ? 14 : 13] ?? "",
+                    lines: [gutter + (parts[hasParentIds ? 14 : 13] ?? "")],
                 }
                 continue
             }
@@ -102,26 +120,38 @@ function parseLogLine(line: string, state: LogStreamState): Commit | null {
         if (parts.length >= 14) {
             const completed = state.current
             const gutter = parts[0] ?? ""
-            const bookmarksRaw = stripAnsi(parts[10] ?? "")
-            const workingCopiesRaw = stripAnsi(parts[12] ?? "")
+            const hasParentIds = parts.length >= 15
+            const parentCommitIdsRaw = hasParentIds
+                ? stripAnsi(parts[3] ?? "")
+                : ""
+            const bookmarksRaw = stripAnsi(parts[hasParentIds ? 11 : 10] ?? "")
+            const workingCopiesRaw = stripAnsi(
+                parts[hasParentIds ? 13 : 12] ?? "",
+            )
             state.current = {
                 changeId: stripAnsi(parts[1] ?? ""),
                 commitId: stripAnsi(parts[2] ?? ""),
-                immutable: stripAnsi(parts[3] ?? "") === "true",
-                empty: stripAnsi(parts[4] ?? "") === "true",
-                divergent: stripAnsi(parts[5] ?? "") === "true",
-                description: stripAnsi(parts[6] ?? ""),
-                author: stripAnsi(parts[7] ?? ""),
-                authorEmail: stripAnsi(parts[8] ?? ""),
-                timestamp: stripAnsi(parts[9] ?? ""),
+                parentCommitIds: parentCommitIdsRaw
+                    ? parentCommitIdsRaw.split(",")
+                    : [],
+                immutable:
+                    stripAnsi(parts[hasParentIds ? 4 : 3] ?? "") === "true",
+                empty: stripAnsi(parts[hasParentIds ? 5 : 4] ?? "") === "true",
+                divergent:
+                    stripAnsi(parts[hasParentIds ? 6 : 5] ?? "") === "true",
+                description: stripAnsi(parts[hasParentIds ? 7 : 6] ?? ""),
+                author: stripAnsi(parts[hasParentIds ? 8 : 7] ?? ""),
+                authorEmail: stripAnsi(parts[hasParentIds ? 9 : 8] ?? ""),
+                timestamp: stripAnsi(parts[hasParentIds ? 10 : 9] ?? ""),
                 bookmarks: bookmarksRaw ? bookmarksRaw.split(",") : [],
-                gitHead: stripAnsi(parts[11] ?? "") === "true",
+                gitHead:
+                    stripAnsi(parts[hasParentIds ? 12 : 11] ?? "") === "true",
                 workingCopies: workingCopiesRaw
                     ? workingCopiesRaw.split(",")
                     : [],
                 isWorkingCopy: gutter.includes("@"),
-                refLine: parts[13] ?? "",
-                lines: [gutter + (parts[13] ?? "")],
+                refLine: parts[hasParentIds ? 14 : 13] ?? "",
+                lines: [gutter + (parts[hasParentIds ? 14 : 13] ?? "")],
             }
             return completed
         }

--- a/src/commander/operations.ts
+++ b/src/commander/operations.ts
@@ -292,7 +292,7 @@ export function isImmutableError(result: OperationResult): boolean {
     )
 }
 
-export interface RebaseOptions {
+export interface RebaseOptions extends OperationRunOptions {
     mode?: "revision" | "descendants" | "branch"
     targetMode?: "onto" | "insertAfter" | "insertBefore"
     skipEmptied?: boolean
@@ -330,7 +330,12 @@ export async function jjRebase(
     if (options?.ignoreImmutable) {
         args.push("--ignore-immutable")
     }
-    const result = await execute(args)
+    const result = options?.observer
+        ? await execute(args, {
+              observer: options.observer,
+              command: `jj ${args.join(" ")}`,
+          })
+        : await execute(args)
     return {
         ...result,
         command: `jj ${args.join(" ")}`,

--- a/src/commander/operations.ts
+++ b/src/commander/operations.ts
@@ -414,13 +414,18 @@ export async function jjShowDescriptionStyled(
 
 export async function jjAbandon(
     revision: string,
-    options?: { ignoreImmutable?: boolean },
+    options?: { ignoreImmutable?: boolean } & OperationRunOptions,
 ): Promise<OperationResult> {
     const args = ["abandon", revision]
     if (options?.ignoreImmutable) {
         args.push("--ignore-immutable")
     }
-    const result = await execute(args)
+    const result = options?.observer
+        ? await execute(args, {
+              observer: options.observer,
+              command: `jj ${args.join(" ")}`,
+          })
+        : await execute(args)
     return {
         ...result,
         command: `jj ${args.join(" ")}`,

--- a/src/commander/operations.ts
+++ b/src/commander/operations.ts
@@ -412,6 +412,20 @@ export async function jjShowDescriptionStyled(
     return { subject, body }
 }
 
+export async function jjRevsetHasMatches(revset: string): Promise<boolean> {
+    const result = await execute([
+        "log",
+        "-r",
+        revset,
+        "--no-graph",
+        "--limit",
+        "1",
+        "-T",
+        "commit_id",
+    ])
+    return result.success && result.stdout.trim().length > 0
+}
+
 export async function jjAbandon(
     revision: string,
     options?: { ignoreImmutable?: boolean } & OperationRunOptions,

--- a/src/commander/types.ts
+++ b/src/commander/types.ts
@@ -1,6 +1,7 @@
 export interface Commit {
     changeId: string
     commitId: string
+    parentCommitIds?: string[]
     description: string
     author: string
     authorEmail: string

--- a/src/components/BookmarkStackRowView.tsx
+++ b/src/components/BookmarkStackRowView.tsx
@@ -16,6 +16,8 @@ interface BookmarkStackRowViewProps {
     prNumber?: number
     showOriginChanged?: boolean
     showRemote?: boolean
+    annotation?: string
+    hideRevisionId?: boolean
 }
 
 export function BookmarkStackRowView(props: BookmarkStackRowViewProps) {
@@ -91,22 +93,24 @@ export function BookmarkStackRowView(props: BookmarkStackRowViewProps) {
                         }
                     >
                         <span style={{ fg: colors().textMuted }}> </span>
-                        <For
-                            each={inlineAnsiSpans(
-                                bookmark().changeIdDisplay ||
-                                    bookmark().changeId,
-                                props.selected
-                                    ? colors().selectionText
-                                    : colors().textMuted,
-                            )}
-                        >
-                            {(span) => (
-                                <span style={{ fg: span.fg, bg: span.bg }}>
-                                    {span.text}
-                                </span>
-                            )}
-                        </For>
-                        <span style={{ fg: colors().textMuted }}> </span>
+                        <Show when={!props.hideRevisionId}>
+                            <For
+                                each={inlineAnsiSpans(
+                                    bookmark().changeIdDisplay ||
+                                        bookmark().changeId,
+                                    props.selected
+                                        ? colors().selectionText
+                                        : colors().textMuted,
+                                )}
+                            >
+                                {(span) => (
+                                    <span style={{ fg: span.fg, bg: span.bg }}>
+                                        {span.text}
+                                    </span>
+                                )}
+                            </For>
+                            <span style={{ fg: colors().textMuted }}> </span>
+                        </Show>
                     </Show>
                     <Show when={props.showRemote && bookmark().remote}>
                         <span style={{ fg: colors().textMuted }}>
@@ -118,36 +122,47 @@ export function BookmarkStackRowView(props: BookmarkStackRowViewProps) {
             <Show when={!isDeleted()}>
                 <box flexDirection="row" flexGrow={1} overflow="hidden">
                     <Show
-                        when={stripAnsi(
-                            bookmark().descriptionDisplay,
-                        ).startsWith(emptyDescriptionPrefix)}
+                        when={props.annotation !== undefined}
                         fallback={
-                            <text
-                                fg={colors().textMuted}
-                                content={bookmark().description}
-                                wrapMode="none"
-                            />
+                            <Show
+                                when={stripAnsi(
+                                    bookmark().descriptionDisplay,
+                                ).startsWith(emptyDescriptionPrefix)}
+                                fallback={
+                                    <text
+                                        fg={colors().textMuted}
+                                        content={bookmark().description}
+                                        wrapMode="none"
+                                    />
+                                }
+                            >
+                                <box
+                                    width={emptyDescriptionPrefix.length}
+                                    flexShrink={0}
+                                >
+                                    <text
+                                        fg={colors().success}
+                                        content={emptyDescriptionPrefix}
+                                        wrapMode="none"
+                                    />
+                                </box>
+                                <box flexGrow={1} overflow="hidden">
+                                    <text
+                                        fg={colors().textMuted}
+                                        content={bookmark().description.slice(
+                                            emptyDescriptionPrefix.length,
+                                        )}
+                                        wrapMode="none"
+                                    />
+                                </box>
+                            </Show>
                         }
                     >
-                        <box
-                            width={emptyDescriptionPrefix.length}
-                            flexShrink={0}
-                        >
-                            <text
-                                fg={colors().success}
-                                content={emptyDescriptionPrefix}
-                                wrapMode="none"
-                            />
-                        </box>
-                        <box flexGrow={1} overflow="hidden">
-                            <text
-                                fg={colors().textMuted}
-                                content={bookmark().description.slice(
-                                    emptyDescriptionPrefix.length,
-                                )}
-                                wrapMode="none"
-                            />
-                        </box>
+                        <text
+                            fg={colors().text}
+                            content={props.annotation}
+                            wrapMode="none"
+                        />
                     </Show>
                 </box>
             </Show>

--- a/src/components/BookmarkStackRowView.tsx
+++ b/src/components/BookmarkStackRowView.tsx
@@ -18,6 +18,7 @@ interface BookmarkStackRowViewProps {
     showRemote?: boolean
     annotation?: string
     hideRevisionId?: boolean
+    hideDescription?: boolean
 }
 
 export function BookmarkStackRowView(props: BookmarkStackRowViewProps) {
@@ -119,7 +120,7 @@ export function BookmarkStackRowView(props: BookmarkStackRowViewProps) {
                     </Show>
                 </text>
             </box>
-            <Show when={!isDeleted()}>
+            <Show when={!isDeleted() && !props.hideDescription}>
                 <box flexDirection="row" flexGrow={1} overflow="hidden">
                     <Show
                         when={props.annotation !== undefined}

--- a/src/components/BookmarkStackRowView.tsx
+++ b/src/components/BookmarkStackRowView.tsx
@@ -1,0 +1,156 @@
+import { ptyToJson } from "ghostty-opentui"
+import { For, Show } from "solid-js"
+import type { Bookmark } from "../commander/bookmarks"
+import { useTheme } from "../context/theme"
+import type { BookmarkStackRow } from "../stack/model"
+import { resolveAnsiForeground } from "../theme/ansi"
+
+const emptyDescriptionPrefix = "(empty) "
+
+// biome-ignore lint/suspicious/noControlCharactersInRegex: intentional ANSI escape sequence
+const stripAnsi = (str: string) => str.replace(/\x1b\[[0-9;]*m/g, "")
+
+interface BookmarkStackRowViewProps {
+    row: BookmarkStackRow<Bookmark>
+    selected?: boolean
+    prNumber?: number
+    showOriginChanged?: boolean
+    showRemote?: boolean
+}
+
+export function BookmarkStackRowView(props: BookmarkStackRowViewProps) {
+    const { colors, mode } = useTheme()
+
+    const inlineAnsiSpans = (content: string, defaultFg?: string) => {
+        const spans =
+            ptyToJson(content, { cols: 9999, rows: 1 }).lines[0]?.spans ?? []
+        return spans
+            .filter((span) => span.text.length > 0)
+            .map((span) => ({
+                text: span.text,
+                fg: resolveAnsiForeground({
+                    fg: span.fg,
+                    mode: mode(),
+                    text: colors().text,
+                    textMuted: colors().textMuted,
+                    defaultFg,
+                }),
+                bg: span.bg ?? undefined,
+            }))
+    }
+
+    const bookmark = () => props.row.bookmark
+    const isDeleted = () => !bookmark().changeId
+    const selectedFg = () =>
+        props.selected ? colors().selectionText : undefined
+    const bookmarkNameFg = (defaultFg?: string) =>
+        inlineAnsiSpans(
+            bookmark().nameDisplay || bookmark().name,
+            defaultFg,
+        ).at(-1)?.fg ??
+        defaultFg ??
+        colors().text
+
+    return (
+        <box flexDirection="row" flexGrow={1} overflow="hidden">
+            <box flexShrink={0} overflow="hidden">
+                <text wrapMode="none">
+                    <Show when={props.row.depth > 0}>
+                        <span style={{ fg: colors().textMuted }}>
+                            {"  ".repeat(Math.max(0, props.row.depth - 1))}↳{" "}
+                        </span>
+                    </Show>
+                    <For
+                        each={inlineAnsiSpans(
+                            bookmark().nameDisplay || bookmark().name,
+                            selectedFg(),
+                        )}
+                    >
+                        {(span) => (
+                            <span style={{ fg: span.fg, bg: span.bg }}>
+                                {span.text}
+                            </span>
+                        )}
+                    </For>
+                    <Show when={bookmark().isLocal && props.showOriginChanged}>
+                        <span style={{ fg: bookmarkNameFg(selectedFg()) }}>
+                            *
+                        </span>
+                    </Show>
+                    <Show when={props.prNumber}>
+                        <span style={{ fg: colors().textMuted }}>
+                            {` #${props.prNumber}`}
+                        </span>
+                    </Show>
+                    <Show
+                        when={!isDeleted()}
+                        fallback={
+                            <span style={{ fg: colors().error }}>
+                                {" –deleted "}
+                            </span>
+                        }
+                    >
+                        <span style={{ fg: colors().textMuted }}> </span>
+                        <For
+                            each={inlineAnsiSpans(
+                                bookmark().changeIdDisplay ||
+                                    bookmark().changeId,
+                                props.selected
+                                    ? colors().selectionText
+                                    : colors().textMuted,
+                            )}
+                        >
+                            {(span) => (
+                                <span style={{ fg: span.fg, bg: span.bg }}>
+                                    {span.text}
+                                </span>
+                            )}
+                        </For>
+                        <span style={{ fg: colors().textMuted }}> </span>
+                    </Show>
+                    <Show when={props.showRemote && bookmark().remote}>
+                        <span style={{ fg: colors().textMuted }}>
+                            @{bookmark().remote}{" "}
+                        </span>
+                    </Show>
+                </text>
+            </box>
+            <Show when={!isDeleted()}>
+                <box flexDirection="row" flexGrow={1} overflow="hidden">
+                    <Show
+                        when={stripAnsi(
+                            bookmark().descriptionDisplay,
+                        ).startsWith(emptyDescriptionPrefix)}
+                        fallback={
+                            <text
+                                fg={colors().textMuted}
+                                content={bookmark().description}
+                                wrapMode="none"
+                            />
+                        }
+                    >
+                        <box
+                            width={emptyDescriptionPrefix.length}
+                            flexShrink={0}
+                        >
+                            <text
+                                fg={colors().success}
+                                content={emptyDescriptionPrefix}
+                                wrapMode="none"
+                            />
+                        </box>
+                        <box flexGrow={1} overflow="hidden">
+                            <text
+                                fg={colors().textMuted}
+                                content={bookmark().description.slice(
+                                    emptyDescriptionPrefix.length,
+                                )}
+                                wrapMode="none"
+                            />
+                        </box>
+                    </Show>
+                </box>
+            </Show>
+        </box>
+    )
+}

--- a/src/components/modals/ActionMenuModal.tsx
+++ b/src/components/modals/ActionMenuModal.tsx
@@ -13,6 +13,8 @@ export interface ActionMenuOption {
 
 interface ActionMenuModalProps {
     options: ActionMenuOption[]
+    paddingLeft?: number
+    paddingRight?: number
 }
 
 export function ActionMenuModal(props: ActionMenuModalProps) {
@@ -89,8 +91,8 @@ export function ActionMenuModal(props: ActionMenuModalProps) {
                     <box
                         flexDirection="row"
                         justifyContent="space-between"
-                        paddingLeft={1}
-                        paddingRight={1}
+                        paddingLeft={props.paddingLeft ?? 0}
+                        paddingRight={props.paddingRight ?? 0}
                         backgroundColor={
                             index() === selectedIndex()
                                 ? colors().selectionBackground

--- a/src/components/modals/StackActionsModal.tsx
+++ b/src/components/modals/StackActionsModal.tsx
@@ -1,0 +1,148 @@
+import { useKeyboard } from "@opentui/solid"
+import { For, Show, createSignal } from "solid-js"
+import type { Bookmark } from "../../commander/bookmarks"
+import { useDialog } from "../../context/dialog"
+import { useTheme } from "../../context/theme"
+import type { BookmarkStackRow } from "../../stack/model"
+import { BookmarkStackRowView } from "../BookmarkStackRowView"
+
+export interface StackActionOption {
+    key: string
+    mutedPrefix?: string
+    label: string
+    onSelect: () => void
+}
+
+interface StackActionsModalProps {
+    stackRootName: string
+    rows: readonly BookmarkStackRow<Bookmark>[]
+    prNumbers: ReadonlyMap<string, number>
+    actions: readonly StackActionOption[]
+}
+
+export function StackActionsModal(props: StackActionsModalProps) {
+    const dialog = useDialog()
+    const { colors } = useTheme()
+    const [selectedIndex, setSelectedIndex] = createSignal(0)
+
+    let executing = false
+
+    const execute = (index: number) => {
+        const action = props.actions[index]
+        if (!action || executing) return
+        executing = true
+        dialog.close()
+        action.onSelect()
+    }
+
+    const selectNext = () => {
+        if (props.actions.length === 0) return
+        setSelectedIndex((index) =>
+            Math.min(props.actions.length - 1, index + 1),
+        )
+    }
+
+    const selectPrev = () => {
+        if (props.actions.length === 0) return
+        setSelectedIndex((index) => Math.max(0, index - 1))
+    }
+
+    useKeyboard((evt) => {
+        if (evt.name === "escape") {
+            evt.preventDefault()
+            evt.stopPropagation()
+            dialog.close()
+            return
+        }
+
+        if (evt.name === "down") {
+            evt.preventDefault()
+            evt.stopPropagation()
+            selectNext()
+            return
+        }
+
+        if (evt.name === "up") {
+            evt.preventDefault()
+            evt.stopPropagation()
+            selectPrev()
+            return
+        }
+
+        if (evt.name === "return" || evt.name === "enter") {
+            evt.preventDefault()
+            evt.stopPropagation()
+            execute(selectedIndex())
+            return
+        }
+
+        if (evt.name && evt.name.length === 1) {
+            const exactIndex = props.actions.findIndex(
+                (action) => action.key === evt.name,
+            )
+            const index =
+                exactIndex >= 0
+                    ? exactIndex
+                    : props.actions.findIndex(
+                          (action) =>
+                              action.key.toLowerCase() ===
+                              evt.name?.toLowerCase(),
+                      )
+            if (index >= 0) {
+                evt.preventDefault()
+                evt.stopPropagation()
+                execute(index)
+            }
+        }
+    })
+
+    return (
+        <box flexDirection="column" gap={1} minHeight={10}>
+            <box flexDirection="column">
+                <For each={props.rows}>
+                    {(row) => (
+                        <box flexDirection="row" overflow="hidden">
+                            <BookmarkStackRowView
+                                row={row}
+                                prNumber={props.prNumbers.get(
+                                    row.bookmark.name,
+                                )}
+                            />
+                        </box>
+                    )}
+                </For>
+            </box>
+
+            <box flexDirection="column">
+                <For each={props.actions}>
+                    {(action, index) => (
+                        <box
+                            flexDirection="row"
+                            justifyContent="space-between"
+                            backgroundColor={
+                                index() === selectedIndex()
+                                    ? colors().selectionBackground
+                                    : undefined
+                            }
+                            onMouseDown={() => setSelectedIndex(index())}
+                        >
+                            <text wrapMode="none" flexGrow={1}>
+                                <Show when={action.mutedPrefix}>
+                                    <span style={{ fg: colors().textMuted }}>
+                                        {action.mutedPrefix}
+                                    </span>
+                                </Show>
+                                <span style={{ fg: colors().text }}>
+                                    {action.label}
+                                </span>
+                            </text>
+                            <text wrapMode="none" fg={colors().primary}>
+                                {action.key}
+                            </text>
+                        </box>
+                    )}
+                </For>
+            </box>
+        </box>
+    )
+}

--- a/src/components/modals/StackActionsModal.tsx
+++ b/src/components/modals/StackActionsModal.tsx
@@ -100,6 +100,7 @@ export function StackActionsModal(props: StackActionsModalProps) {
                                 prNumber={props.prNumbers.get(
                                     row.bookmark.name,
                                 )}
+                                hideDescription
                             />
                         </box>
                     )}

--- a/src/components/modals/StackActionsModal.tsx
+++ b/src/components/modals/StackActionsModal.tsx
@@ -77,17 +77,10 @@ export function StackActionsModal(props: StackActionsModalProps) {
         }
 
         if (evt.name && evt.name.length === 1) {
-            const exactIndex = props.actions.findIndex(
-                (action) => action.key === evt.name,
+            const key = evt.shift ? evt.name.toUpperCase() : evt.name
+            const index = props.actions.findIndex(
+                (action) => action.key === key,
             )
-            const index =
-                exactIndex >= 0
-                    ? exactIndex
-                    : props.actions.findIndex(
-                          (action) =>
-                              action.key.toLowerCase() ===
-                              evt.name?.toLowerCase(),
-                      )
             if (index >= 0) {
                 evt.preventDefault()
                 evt.stopPropagation()

--- a/src/components/modals/StackPlanModal.tsx
+++ b/src/components/modals/StackPlanModal.tsx
@@ -1,0 +1,86 @@
+import { useKeyboard } from "@opentui/solid"
+import { For, Show } from "solid-js"
+import type { Bookmark } from "../../commander/bookmarks"
+import { useDialog } from "../../context/dialog"
+import { useTheme } from "../../context/theme"
+import type { StackPlan } from "../../stack/model"
+import { BookmarkStackRowView } from "../BookmarkStackRowView"
+
+interface StackPlanModalProps {
+    plan: StackPlan<Bookmark>
+    onApply: () => void
+    onBack: () => void
+}
+
+export function StackPlanModal(props: StackPlanModalProps) {
+    const dialog = useDialog()
+    const { colors } = useTheme()
+    let applying = false
+
+    const apply = () => {
+        if (applying) return
+        applying = true
+        dialog.close()
+        props.onApply()
+    }
+
+    useKeyboard((evt) => {
+        if (evt.name === "escape") {
+            evt.preventDefault()
+            evt.stopPropagation()
+            dialog.close()
+            props.onBack()
+            return
+        }
+
+        if (evt.name === "return" || evt.name === "enter") {
+            evt.preventDefault()
+            evt.stopPropagation()
+            apply()
+        }
+    })
+
+    return (
+        <box flexDirection="column" gap={1} minHeight={10}>
+            <box flexDirection="column">
+                <For each={props.plan.rows}>
+                    {(row) => (
+                        <box flexDirection="row" overflow="hidden">
+                            <BookmarkStackRowView
+                                row={row.row}
+                                prNumber={row.prNumber}
+                                annotation={row.note}
+                                hideRevisionId
+                            />
+                        </box>
+                    )}
+                </For>
+            </box>
+
+            <box flexDirection="column">
+                <Show when={props.plan.updatePrNumbers.length > 0}>
+                    <text wrapMode="none" fg={colors().text}>
+                        {`Would update PRs: ${props.plan.updatePrNumbers
+                            .map((number) => `#${number}`)
+                            .join(", ")}`}
+                    </text>
+                </Show>
+                <Show when={props.plan.createPrBookmarks.length > 0}>
+                    <text wrapMode="none" fg={colors().text}>
+                        {`Would create PRs: ${props.plan.createPrBookmarks.join(", ")}`}
+                    </text>
+                </Show>
+                <Show when={props.plan.pushBookmarks.length > 0}>
+                    <text wrapMode="none" fg={colors().text}>
+                        {`Would push: ${props.plan.pushBookmarks.join(", ")}`}
+                    </text>
+                </Show>
+                <Show when={props.plan.rebaseBookmarks.length > 0}>
+                    <text wrapMode="none" fg={colors().text}>
+                        {`Would rebase: ${props.plan.rebaseBookmarks.join(", ")}`}
+                    </text>
+                </Show>
+            </box>
+        </box>
+    )
+}

--- a/src/components/modals/StackPlanModal.tsx
+++ b/src/components/modals/StackPlanModal.tsx
@@ -80,6 +80,11 @@ export function StackPlanModal(props: StackPlanModalProps) {
                         {`Would rebase: ${props.plan.rebaseBookmarks.join(", ")}`}
                     </text>
                 </Show>
+                <Show when={props.plan.abandonBookmarks.length > 0}>
+                    <text wrapMode="none" fg={colors().text}>
+                        {`Would abandon: ${props.plan.abandonBookmarks.join(", ")}`}
+                    </text>
+                </Show>
                 <Show when={props.plan.closePrNumbers.length > 0}>
                     <text wrapMode="none" fg={colors().text}>
                         {`Would close PRs: ${props.plan.closePrNumbers

--- a/src/components/modals/StackPlanModal.tsx
+++ b/src/components/modals/StackPlanModal.tsx
@@ -16,6 +16,7 @@ export function StackPlanModal(props: StackPlanModalProps) {
     const dialog = useDialog()
     const { colors } = useTheme()
     const hasEffects = () => props.plan.effects.length > 0
+    const actionLines = () => stackActionLines(props.plan)
     let applying = false
 
     const apply = () => {
@@ -70,42 +71,201 @@ export function StackPlanModal(props: StackPlanModalProps) {
 
             <Show when={hasEffects()}>
                 <box flexDirection="column">
-                    <Show when={props.plan.updatePrNumbers.length > 0}>
-                        <text wrapMode="none" fg={colors().text}>
-                            {`Would update PRs: ${props.plan.updatePrNumbers
-                                .map((number) => `#${number}`)
-                                .join(", ")}`}
-                        </text>
-                    </Show>
-                    <Show when={props.plan.createPrBookmarks.length > 0}>
-                        <text wrapMode="none" fg={colors().text}>
-                            {`Would create PRs: ${props.plan.createPrBookmarks.join(", ")}`}
-                        </text>
-                    </Show>
-                    <Show when={props.plan.pushBookmarks.length > 0}>
-                        <text wrapMode="none" fg={colors().text}>
-                            {`Would push: ${props.plan.pushBookmarks.join(", ")}`}
-                        </text>
-                    </Show>
-                    <Show when={props.plan.rebaseBookmarks.length > 0}>
-                        <text wrapMode="none" fg={colors().text}>
-                            {`Would rebase: ${props.plan.rebaseBookmarks.join(", ")}`}
-                        </text>
-                    </Show>
-                    <Show when={props.plan.abandonBookmarks.length > 0}>
-                        <text wrapMode="none" fg={colors().text}>
-                            {`Would abandon: ${props.plan.abandonBookmarks.join(", ")}`}
-                        </text>
-                    </Show>
-                    <Show when={props.plan.closePrNumbers.length > 0}>
-                        <text wrapMode="none" fg={colors().text}>
-                            {`Would close PRs: ${props.plan.closePrNumbers
-                                .map((number) => `#${number}`)
-                                .join(", ")}`}
-                        </text>
-                    </Show>
+                    <For each={actionLines()}>
+                        {(line) => (
+                            <text wrapMode="none" fg={colors().text}>
+                                <span style={{ fg: colors().textMuted }}>
+                                    →{" "}
+                                </span>
+                                <For each={line}>
+                                    {(segment) => (
+                                        <span
+                                            style={{
+                                                fg:
+                                                    segment.kind === "action"
+                                                        ? colors().warning
+                                                        : segment.kind ===
+                                                            "identifier"
+                                                          ? colors().primary
+                                                          : colors().text,
+                                            }}
+                                        >
+                                            {segment.text}
+                                        </span>
+                                    )}
+                                </For>
+                            </text>
+                        )}
+                    </For>
                 </box>
             </Show>
         </box>
     )
+}
+
+type ActionLineSegment = {
+    readonly text: string
+    readonly kind?: "action" | "identifier"
+}
+
+function stackActionLines(
+    plan: StackPlan<Bookmark>,
+): readonly ActionLineSegment[][] {
+    const lines: ActionLineSegment[][] = []
+    const effects = plan.effects
+    const pushBookmarks = unique(
+        effects
+            .filter((effect) => effect.type === "push")
+            .map((effect) => effect.bookmark),
+    )
+
+    for (const effect of effects) {
+        if (effect.type === "abandon") {
+            lines.push([
+                action("abandon"),
+                text(" merged local change "),
+                identifier(effect.bookmark),
+            ])
+        }
+        if (effect.type === "abandon-landed-range") {
+            lines.push([
+                action("abandon"),
+                text(" landed parent range from "),
+                identifier(effect.bookmark),
+            ])
+        }
+    }
+
+    if (pushBookmarks.length > 0) {
+        lines.push([action("push"), text(" "), identifiers(pushBookmarks)])
+    }
+
+    for (const effect of effects) {
+        if (effect.type === "create-pr") {
+            lines.push([
+                action("create PR"),
+                text(" for "),
+                identifier(effect.bookmark),
+                text(" onto "),
+                identifier(effect.to ?? plan.stackRootName),
+            ])
+        }
+    }
+
+    for (const effect of effects) {
+        if (effect.type === "rebase") {
+            lines.push(
+                effect.from
+                    ? [
+                          action("rebase"),
+                          text(" "),
+                          identifier(effect.bookmark),
+                          text(" from "),
+                          identifier(effect.from),
+                          text(" onto "),
+                          identifier(effect.to ?? "target"),
+                      ]
+                    : [
+                          action("rebase"),
+                          text(" "),
+                          identifier(effect.bookmark),
+                          text(" onto "),
+                          identifier(effect.to ?? "target"),
+                      ],
+            )
+        }
+    }
+
+    for (const effect of effects) {
+        if (effect.type === "update-pr" && effect.prNumber) {
+            lines.push(
+                effect.from
+                    ? [
+                          action("retarget"),
+                          text(" "),
+                          identifier(`#${effect.prNumber}`),
+                          text(" ("),
+                          identifier(effect.bookmark),
+                          text(") from "),
+                          identifier(effect.from),
+                          text(" to "),
+                          identifier(effect.to ?? "target"),
+                      ]
+                    : [
+                          action("retarget"),
+                          text(" "),
+                          identifier(`#${effect.prNumber}`),
+                          text(" ("),
+                          identifier(effect.bookmark),
+                          text(") to "),
+                          identifier(effect.to ?? "target"),
+                      ],
+            )
+        }
+    }
+
+    for (const effect of effects) {
+        if (effect.type === "close-pr" && effect.prNumber) {
+            lines.push([
+                action("close"),
+                text(" "),
+                identifier(`#${effect.prNumber}`),
+                text(" ("),
+                identifier(effect.bookmark),
+                text(effect.reason ? `): ${effect.reason}` : ")"),
+            ])
+        }
+        if (effect.type === "blocked") {
+            lines.push([
+                action("blocked"),
+                text(" "),
+                identifier(effect.bookmark),
+                text(effect.reason ? `: ${effect.reason}` : ""),
+            ])
+        }
+    }
+
+    const commentPrNumbers = unique(
+        effects
+            .filter(
+                (effect) => effect.type === "update-comment" && effect.prNumber,
+            )
+            .map((effect) => effect.prNumber ?? 0),
+    )
+    if (commentPrNumbers.length === 1) {
+        lines.push([
+            action("update"),
+            text(" "),
+            identifier(`#${commentPrNumbers[0]}`),
+            text(" stack block"),
+        ])
+    } else if (commentPrNumbers.length > 1) {
+        lines.push([
+            action("update"),
+            text(" stack blocks for "),
+            identifiers(commentPrNumbers.map((number) => `#${number}`)),
+        ])
+    }
+
+    return lines
+}
+
+function action(textValue: string): ActionLineSegment {
+    return { text: textValue, kind: "action" }
+}
+
+function identifier(textValue: string): ActionLineSegment {
+    return { text: textValue, kind: "identifier" }
+}
+
+function identifiers(values: readonly string[]): ActionLineSegment {
+    return identifier(values.join(", "))
+}
+
+function text(textValue: string): ActionLineSegment {
+    return { text: textValue }
+}
+
+function unique<T>(items: readonly T[]): readonly T[] {
+    return [...new Set(items)]
 }

--- a/src/components/modals/StackPlanModal.tsx
+++ b/src/components/modals/StackPlanModal.tsx
@@ -80,6 +80,13 @@ export function StackPlanModal(props: StackPlanModalProps) {
                         {`Would rebase: ${props.plan.rebaseBookmarks.join(", ")}`}
                     </text>
                 </Show>
+                <Show when={props.plan.closePrNumbers.length > 0}>
+                    <text wrapMode="none" fg={colors().text}>
+                        {`Would close PRs: ${props.plan.closePrNumbers
+                            .map((number) => `#${number}`)
+                            .join(", ")}`}
+                    </text>
+                </Show>
             </box>
         </box>
     )

--- a/src/components/modals/StackPlanModal.tsx
+++ b/src/components/modals/StackPlanModal.tsx
@@ -15,10 +15,11 @@ interface StackPlanModalProps {
 export function StackPlanModal(props: StackPlanModalProps) {
     const dialog = useDialog()
     const { colors } = useTheme()
+    const hasEffects = () => props.plan.effects.length > 0
     let applying = false
 
     const apply = () => {
-        if (applying) return
+        if (!hasEffects() || applying) return
         applying = true
         dialog.close()
         props.onApply()
@@ -43,6 +44,16 @@ export function StackPlanModal(props: StackPlanModalProps) {
     return (
         <box flexDirection="column" gap={1} minHeight={10}>
             <box flexDirection="column">
+                <Show when={!hasEffects()}>
+                    <box flexDirection="column" gap={1} paddingLeft={1}>
+                        <text wrapMode="none" fg={colors().success}>
+                            Nothing to do
+                        </text>
+                        <text wrapMode="none" fg={colors().textMuted}>
+                            This stack is already in sync with GitHub.
+                        </text>
+                    </box>
+                </Show>
                 <For each={props.plan.rows}>
                     {(row) => (
                         <box flexDirection="row" overflow="hidden">
@@ -57,42 +68,44 @@ export function StackPlanModal(props: StackPlanModalProps) {
                 </For>
             </box>
 
-            <box flexDirection="column">
-                <Show when={props.plan.updatePrNumbers.length > 0}>
-                    <text wrapMode="none" fg={colors().text}>
-                        {`Would update PRs: ${props.plan.updatePrNumbers
-                            .map((number) => `#${number}`)
-                            .join(", ")}`}
-                    </text>
-                </Show>
-                <Show when={props.plan.createPrBookmarks.length > 0}>
-                    <text wrapMode="none" fg={colors().text}>
-                        {`Would create PRs: ${props.plan.createPrBookmarks.join(", ")}`}
-                    </text>
-                </Show>
-                <Show when={props.plan.pushBookmarks.length > 0}>
-                    <text wrapMode="none" fg={colors().text}>
-                        {`Would push: ${props.plan.pushBookmarks.join(", ")}`}
-                    </text>
-                </Show>
-                <Show when={props.plan.rebaseBookmarks.length > 0}>
-                    <text wrapMode="none" fg={colors().text}>
-                        {`Would rebase: ${props.plan.rebaseBookmarks.join(", ")}`}
-                    </text>
-                </Show>
-                <Show when={props.plan.abandonBookmarks.length > 0}>
-                    <text wrapMode="none" fg={colors().text}>
-                        {`Would abandon: ${props.plan.abandonBookmarks.join(", ")}`}
-                    </text>
-                </Show>
-                <Show when={props.plan.closePrNumbers.length > 0}>
-                    <text wrapMode="none" fg={colors().text}>
-                        {`Would close PRs: ${props.plan.closePrNumbers
-                            .map((number) => `#${number}`)
-                            .join(", ")}`}
-                    </text>
-                </Show>
-            </box>
+            <Show when={hasEffects()}>
+                <box flexDirection="column">
+                    <Show when={props.plan.updatePrNumbers.length > 0}>
+                        <text wrapMode="none" fg={colors().text}>
+                            {`Would update PRs: ${props.plan.updatePrNumbers
+                                .map((number) => `#${number}`)
+                                .join(", ")}`}
+                        </text>
+                    </Show>
+                    <Show when={props.plan.createPrBookmarks.length > 0}>
+                        <text wrapMode="none" fg={colors().text}>
+                            {`Would create PRs: ${props.plan.createPrBookmarks.join(", ")}`}
+                        </text>
+                    </Show>
+                    <Show when={props.plan.pushBookmarks.length > 0}>
+                        <text wrapMode="none" fg={colors().text}>
+                            {`Would push: ${props.plan.pushBookmarks.join(", ")}`}
+                        </text>
+                    </Show>
+                    <Show when={props.plan.rebaseBookmarks.length > 0}>
+                        <text wrapMode="none" fg={colors().text}>
+                            {`Would rebase: ${props.plan.rebaseBookmarks.join(", ")}`}
+                        </text>
+                    </Show>
+                    <Show when={props.plan.abandonBookmarks.length > 0}>
+                        <text wrapMode="none" fg={colors().text}>
+                            {`Would abandon: ${props.plan.abandonBookmarks.join(", ")}`}
+                        </text>
+                    </Show>
+                    <Show when={props.plan.closePrNumbers.length > 0}>
+                        <text wrapMode="none" fg={colors().text}>
+                            {`Would close PRs: ${props.plan.closePrNumbers
+                                .map((number) => `#${number}`)
+                                .join(", ")}`}
+                        </text>
+                    </Show>
+                </box>
+            </Show>
         </box>
     )
 }

--- a/src/components/modals/StackPlanModal.tsx
+++ b/src/components/modals/StackPlanModal.tsx
@@ -61,7 +61,7 @@ export function StackPlanModal(props: StackPlanModalProps) {
                                 row={row.row}
                                 prNumber={row.prNumber}
                                 annotation={row.note}
-                                hideRevisionId
+                                hideDescription
                             />
                         </box>
                     )}

--- a/src/components/modals/StackPlanModal.tsx
+++ b/src/components/modals/StackPlanModal.tsx
@@ -112,14 +112,8 @@ function stackActionLines(
     plan: StackPlan<Bookmark>,
 ): readonly ActionLineSegment[][] {
     const lines: ActionLineSegment[][] = []
-    const effects = plan.effects
-    const pushBookmarks = unique(
-        effects
-            .filter((effect) => effect.type === "push")
-            .map((effect) => effect.bookmark),
-    )
 
-    for (const effect of effects) {
+    for (const effect of plan.effects) {
         if (effect.type === "abandon") {
             lines.push([
                 action("abandon"),
@@ -134,13 +128,9 @@ function stackActionLines(
                 identifier(effect.bookmark),
             ])
         }
-    }
-
-    if (pushBookmarks.length > 0) {
-        lines.push([action("push"), text(" "), identifiers(pushBookmarks)])
-    }
-
-    for (const effect of effects) {
+        if (effect.type === "push") {
+            lines.push([action("push"), text(" "), identifier(effect.bookmark)])
+        }
         if (effect.type === "create-pr") {
             lines.push([
                 action("create PR"),
@@ -150,9 +140,6 @@ function stackActionLines(
                 identifier(effect.to ?? plan.stackRootName),
             ])
         }
-    }
-
-    for (const effect of effects) {
         if (effect.type === "rebase") {
             lines.push(
                 effect.from
@@ -174,9 +161,6 @@ function stackActionLines(
                       ],
             )
         }
-    }
-
-    for (const effect of effects) {
         if (effect.type === "update-pr" && effect.prNumber) {
             lines.push(
                 effect.from
@@ -202,9 +186,6 @@ function stackActionLines(
                       ],
             )
         }
-    }
-
-    for (const effect of effects) {
         if (effect.type === "close-pr" && effect.prNumber) {
             lines.push([
                 action("close"),
@@ -223,28 +204,14 @@ function stackActionLines(
                 text(effect.reason ? `: ${effect.reason}` : ""),
             ])
         }
-    }
-
-    const commentPrNumbers = unique(
-        effects
-            .filter(
-                (effect) => effect.type === "update-comment" && effect.prNumber,
-            )
-            .map((effect) => effect.prNumber ?? 0),
-    )
-    if (commentPrNumbers.length === 1) {
-        lines.push([
-            action("update"),
-            text(" "),
-            identifier(`#${commentPrNumbers[0]}`),
-            text(" stack block"),
-        ])
-    } else if (commentPrNumbers.length > 1) {
-        lines.push([
-            action("update"),
-            text(" stack blocks for "),
-            identifiers(commentPrNumbers.map((number) => `#${number}`)),
-        ])
+        if (effect.type === "update-comment" && effect.prNumber) {
+            lines.push([
+                action("update"),
+                text(" "),
+                identifier(`#${effect.prNumber}`),
+                text(" stack block"),
+            ])
+        }
     }
 
     return lines
@@ -264,8 +231,4 @@ function identifiers(values: readonly string[]): ActionLineSegment {
 
 function text(textValue: string): ActionLineSegment {
     return { text: textValue }
-}
-
-function unique<T>(items: readonly T[]): readonly T[] {
-    return [...new Set(items)]
 }

--- a/src/components/modals/StackPreparingModal.tsx
+++ b/src/components/modals/StackPreparingModal.tsx
@@ -1,0 +1,64 @@
+import { createSignal, onCleanup, onMount } from "solid-js"
+import { useTheme } from "../../context/theme"
+
+interface StackPreparingModalProps {
+    kind: "submit" | "sync"
+    stackRootName: string
+}
+
+const frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+const waveGlyphs = [
+    "▁",
+    "▂",
+    "▃",
+    "▄",
+    "▅",
+    "▆",
+    "▇",
+    "█",
+    "▇",
+    "▆",
+    "▅",
+    "▄",
+    "▃",
+    "▂",
+]
+
+export function StackPreparingModal(props: StackPreparingModalProps) {
+    const { colors } = useTheme()
+    const [tick, setTick] = createSignal(0)
+
+    onMount(() => {
+        const interval = setInterval(() => setTick((value) => value + 1), 80)
+        onCleanup(() => clearInterval(interval))
+    })
+
+    const label = () =>
+        props.kind === "submit"
+            ? "Preparing submit plan"
+            : "Preparing sync plan"
+    const wave = () =>
+        Array.from({ length: 24 }, (_, index) => {
+            const offset = (index + tick()) % waveGlyphs.length
+            return waveGlyphs[offset]
+        }).join("")
+
+    return (
+        <box flexDirection="column" minHeight={10} justifyContent="center">
+            <box flexDirection="column" alignItems="center" gap={1}>
+                <text wrapMode="none" fg={colors().primary}>
+                    {frames[tick() % frames.length]} {label()}
+                </text>
+                <text wrapMode="none" fg={colors().textMuted}>
+                    {props.stackRootName}
+                </text>
+                <text wrapMode="none" fg={colors().primary}>
+                    {wave()}
+                </text>
+                <text wrapMode="none" fg={colors().textMuted}>
+                    Fetching jj and GitHub state…
+                </text>
+            </box>
+        </box>
+    )
+}

--- a/src/components/modals/StackPreparingModal.tsx
+++ b/src/components/modals/StackPreparingModal.tsx
@@ -2,7 +2,7 @@ import { createSignal, onCleanup, onMount } from "solid-js"
 import { useTheme } from "../../context/theme"
 
 interface StackPreparingModalProps {
-    kind: "submit" | "sync"
+    kind: "sync"
     stackRootName: string
 }
 
@@ -33,10 +33,7 @@ export function StackPreparingModal(props: StackPreparingModalProps) {
         onCleanup(() => clearInterval(interval))
     })
 
-    const label = () =>
-        props.kind === "submit"
-            ? "Preparing submit plan"
-            : "Preparing sync plan"
+    const label = () => "Preparing sync plan"
     const wave = () =>
         Array.from({ length: 24 }, (_, index) => {
             const offset = (index + tick()) % waveGlyphs.length

--- a/src/components/modals/StackPreparingModal.tsx
+++ b/src/components/modals/StackPreparingModal.tsx
@@ -1,4 +1,4 @@
-import { createSignal, onCleanup, onMount } from "solid-js"
+import { For, createMemo, createSignal, onCleanup, onMount } from "solid-js"
 import { useTheme } from "../../context/theme"
 
 interface StackPreparingModalProps {
@@ -6,56 +6,151 @@ interface StackPreparingModalProps {
     stackRootName: string
 }
 
-const frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
-const waveGlyphs = [
-    "▁",
-    "▂",
-    "▃",
-    "▄",
-    "▅",
-    "▆",
-    "▇",
-    "█",
-    "▇",
-    "▆",
-    "▅",
-    "▄",
-    "▃",
-    "▂",
+const WIDTH = 44
+const HEIGHT = 11
+const glyphs = [" ", "░", "▒", "▓", "█"]
+
+const loadingMessages = [
+    "Consulting the GitHub oracles…",
+    "Surveying the stacklands…",
+    "Charting your stack…",
+    "Reading the GitHub runes…",
+    "Assembling the stack map…",
+    "Scouting PR terrain…",
+    "Tracing stack paths…",
+    "Inspecting the stack ley lines…",
+    "Gathering stack omens…",
+    "Preparing your stack…",
+    "Polling the pull request spirits…",
+    "Following bookmark trails…",
+    "Mapping GitHub foothills…",
+    "Decoding stack whispers…",
+    "Aligning the PR constellations…",
+    "Reading the branch weather…",
+    "Summoning a stack plan…",
+    "Checking the review currents…",
+    "Walking the stack graph…",
+    "Unfurling the PR parchment…",
 ]
+
+function randomLoadingMessage() {
+    return (
+        loadingMessages[Math.floor(Math.random() * loadingMessages.length)] ??
+        "Preparing your stack…"
+    )
+}
+
+function parseHex(hex: string) {
+    const h = hex.replace("#", "")
+    return {
+        r: Number.parseInt(h.slice(0, 2), 16),
+        g: Number.parseInt(h.slice(2, 4), 16),
+        b: Number.parseInt(h.slice(4, 6), 16),
+    }
+}
+
+function toHex(r: number, g: number, b: number) {
+    const clamp = (n: number) => Math.max(0, Math.min(255, Math.round(n)))
+    const hex = (n: number) => clamp(n).toString(16).padStart(2, "0")
+    return `#${hex(r)}${hex(g)}${hex(b)}`
+}
+
+function lerpColor(from: string, to: string, t: number) {
+    const f = parseHex(from)
+    const c = parseHex(to)
+    return toHex(
+        f.r + (c.r - f.r) * t,
+        f.g + (c.g - f.g) * t,
+        f.b + (c.b - f.b) * t,
+    )
+}
 
 export function StackPreparingModal(props: StackPreparingModalProps) {
     const { colors } = useTheme()
     const [tick, setTick] = createSignal(0)
+    const [message] = createSignal(randomLoadingMessage())
 
     onMount(() => {
-        const interval = setInterval(() => setTick((value) => value + 1), 80)
+        const interval = setInterval(() => setTick((value) => value + 1), 90)
         onCleanup(() => clearInterval(interval))
     })
 
-    const label = () => "Preparing sync plan"
-    const wave = () =>
-        Array.from({ length: 24 }, (_, index) => {
-            const offset = (index + tick()) % waveGlyphs.length
-            return waveGlyphs[offset]
-        }).join("")
+    const rows = createMemo(() => {
+        const t = tick()
+        const pulse = 1 + Math.sin(t * 0.22) * 0.08
+        const cx = WIDTH / 2 - 0.5
+        const cy = HEIGHT / 2 - 0.5
+        const rx = 18 * pulse
+        const ry = 4.4 * pulse
+        const bg = colors().background
+        const primary = colors().primary
+
+        return Array.from({ length: HEIGHT }, (_, y) =>
+            Array.from({ length: WIDTH }, (_, x) => {
+                const nx = (x - cx) / rx
+                const ny = (y - cy) / ry
+                const r = Math.sqrt(nx * nx + ny * ny)
+                if (r > 1.08) return { char: " ", color: bg }
+
+                const base = Math.max(0, 1 - r)
+                const upperLight = Math.max(0, 1 - Math.abs(ny + 0.34) * 2.2)
+                const lowerFade = Math.max(0, 1 - Math.abs(ny - 0.42) * 3.2)
+                const band = Math.sin(x * 0.34 - y * 0.7 + t * 0.38) * 0.5 + 0.5
+                const shimmer =
+                    Math.sin(x * 0.72 + y * 0.28 - t * 0.75) * 0.5 + 0.5
+                const edgeFade = Math.max(0, Math.min(1, (1.08 - r) / 0.28))
+                const intensity = Math.max(
+                    0,
+                    Math.min(
+                        1,
+                        (base ** 0.32 * 0.68 +
+                            upperLight * 0.28 +
+                            lowerFade * 0.12 +
+                            band * 0.16 +
+                            shimmer * 0.12) *
+                            edgeFade,
+                    ),
+                )
+                const glyphIndex = Math.max(
+                    1,
+                    Math.min(4, Math.floor(intensity * 4.5)),
+                )
+                return {
+                    char: glyphs[glyphIndex] ?? "░",
+                    color: lerpColor(bg, primary, 0.25 + intensity * 0.75),
+                }
+            }),
+        )
+    })
 
     return (
-        <box flexDirection="column" minHeight={10} justifyContent="center">
-            <box flexDirection="column" alignItems="center" gap={1}>
-                <text wrapMode="none" fg={colors().primary}>
-                    {frames[tick() % frames.length]} {label()}
-                </text>
-                <text wrapMode="none" fg={colors().textMuted}>
-                    {props.stackRootName}
-                </text>
-                <text wrapMode="none" fg={colors().primary}>
-                    {wave()}
-                </text>
-                <text wrapMode="none" fg={colors().textMuted}>
-                    Fetching jj and GitHub state…
-                </text>
+        <box
+            flexDirection="column"
+            flexGrow={1}
+            justifyContent="center"
+            alignItems="center"
+            paddingTop={1}
+            gap={1}
+        >
+            <box flexDirection="column" alignItems="center">
+                <For each={rows()}>
+                    {(row) => (
+                        <text wrapMode="none">
+                            <For each={row}>
+                                {(cell) => (
+                                    <span style={{ fg: cell.color }}>
+                                        {cell.char}
+                                    </span>
+                                )}
+                            </For>
+                        </text>
+                    )}
+                </For>
             </box>
+            <box height={1} />
+            <text wrapMode="none" fg={colors().text}>
+                {message()}
+            </text>
         </box>
     )
 }

--- a/src/components/panels/BookmarksPanel.tsx
+++ b/src/components/panels/BookmarksPanel.tsx
@@ -53,6 +53,7 @@ import { FUZZY_THRESHOLD, scrollIntoView } from "../../utils/scroll"
 import { AnsiText } from "../AnsiText"
 import { FilterInput } from "../FilterInput"
 import { Panel } from "../Panel"
+import { ActionMenuModal } from "../modals/ActionMenuModal"
 import { BookmarkNameModal } from "../modals/BookmarkNameModal"
 import { RevisionPickerModal } from "../modals/RevisionPickerModal"
 
@@ -363,9 +364,12 @@ export function BookmarksPanel() {
     })
 
     const currentSelectedIndex = () => displaySelectedIndex()
+    const selectedBookmarkRow = createMemo(
+        () => displayBookmarkRows()[currentSelectedIndex()],
+    )
     const activeStackKey = createMemo(() => {
         if (!isFocused()) return undefined
-        const row = displayBookmarkRows()[currentSelectedIndex()]
+        const row = selectedBookmarkRow()
         if (!row) return undefined
         if (
             commits().find(
@@ -376,6 +380,108 @@ export function BookmarksPanel() {
         }
         return row.stackKeys[0]
     })
+
+    const openStackActions = (stackRootName: string) => {
+        dialog.open(
+            () => (
+                <ActionMenuModal
+                    options={[
+                        {
+                            key: "s",
+                            mutedPrefix: "stack ",
+                            label: "submit --dry-run",
+                            onSelect: () =>
+                                status.show(
+                                    `Stack submit dry-run for ${stackRootName} is not implemented yet.`,
+                                ),
+                        },
+                        {
+                            key: "S",
+                            mutedPrefix: "stack ",
+                            label: "submit",
+                            onSelect: () =>
+                                status.show(
+                                    `Stack submit for ${stackRootName} is not implemented yet.`,
+                                ),
+                        },
+                        {
+                            key: "f",
+                            mutedPrefix: "stack ",
+                            label: "sync --dry-run",
+                            onSelect: () =>
+                                status.show(
+                                    `Stack sync dry-run for ${stackRootName} is not implemented yet.`,
+                                ),
+                        },
+                        {
+                            key: "F",
+                            mutedPrefix: "stack ",
+                            label: "sync",
+                            onSelect: () =>
+                                status.show(
+                                    `Stack sync for ${stackRootName} is not implemented yet.`,
+                                ),
+                        },
+                    ]}
+                />
+            ),
+            {
+                id: "bookmark-stack-actions",
+                title: [
+                    { text: "Stack", style: "action" },
+                    " options for ",
+                    { text: stackRootName, style: "target" },
+                ],
+                ...DIALOG_SIZE.confirm,
+                hints: [{ key: "enter", label: "run" }],
+            },
+        )
+    }
+
+    const openStackPicker = (stackRootNames: readonly string[]) => {
+        dialog.open(
+            () => (
+                <ActionMenuModal
+                    options={stackRootNames.map((name, index) => ({
+                        key: String(index + 1),
+                        label: name,
+                        detail: bookmarkPrNumbers().get(name)
+                            ? `#${bookmarkPrNumbers().get(name)}`
+                            : undefined,
+                        onSelect: () => openStackActions(name),
+                    }))}
+                />
+            ),
+            {
+                id: "bookmark-stack-picker",
+                title: [{ text: "Select stack", style: "action" }],
+                ...DIALOG_SIZE.confirm,
+                hints: [
+                    { key: "enter", label: "select" },
+                    { key: "esc", label: "close" },
+                ],
+            },
+        )
+    }
+
+    const openSelectedStack = () => {
+        if (showRemoteOnly()) return
+        const row = selectedBookmarkRow()
+        if (!row) return
+        if (row.stackKeys.length === 0) {
+            status.show(`No stack for ${row.bookmark.name}.`)
+            return
+        }
+        const isTrunk = commits().find(
+            (commit) => commit.commitId === row.bookmark.commitId,
+        )?.immutable
+        if (isTrunk) {
+            openStackPicker(row.stackKeys)
+            return
+        }
+        const stackKey = row.stackKeys[0]
+        if (stackKey) openStackActions(stackKey)
+    }
 
     createEffect(
         on(
@@ -955,6 +1061,15 @@ export function BookmarksPanel() {
                     },
                 )
             },
+        },
+        {
+            id: "refs.bookmarks.stack",
+            title: "stack",
+            keybind: "bookmark_stack",
+            context: "refs.bookmarks",
+            type: "action",
+            panel: "refs",
+            onSelect: openSelectedStack,
         },
         {
             id: "refs.bookmarks.diff_origin",

--- a/src/components/panels/BookmarksPanel.tsx
+++ b/src/components/panels/BookmarksPanel.tsx
@@ -62,6 +62,7 @@ import { BookmarkNameModal } from "../modals/BookmarkNameModal"
 import { RevisionPickerModal } from "../modals/RevisionPickerModal"
 import { StackActionsModal } from "../modals/StackActionsModal"
 import { StackPlanModal } from "../modals/StackPlanModal"
+import { StackPreparingModal } from "../modals/StackPreparingModal"
 
 type BookmarkRow = BookmarkStackRow<Bookmark>
 
@@ -404,8 +405,34 @@ export function BookmarksPanel() {
         kind: "submit" | "sync",
         stackRootName: string,
     ) => {
+        dialog.open(
+            () => (
+                <StackPreparingModal
+                    kind={kind}
+                    stackRootName={stackRootName}
+                />
+            ),
+            {
+                id: `bookmark-stack-${kind}-preparing`,
+                title: [
+                    {
+                        text:
+                            kind === "submit"
+                                ? "Submit preview"
+                                : "Sync preview",
+                        style: "action",
+                    },
+                    " for ",
+                    { text: stackRootName, style: "target" },
+                ],
+                ...DIALOG_SIZE.confirmWide,
+                closeOnEsc: false,
+                hints: [],
+            },
+        )
         try {
             const plan = await preparePlan(kind, stackRootName)
+            dialog.close()
             dialog.open(
                 () => (
                     <StackPlanModal
@@ -436,6 +463,7 @@ export function BookmarksPanel() {
                 },
             )
         } catch (error) {
+            dialog.close()
             status.show(
                 error instanceof Error ? error.message : String(error),
                 {

--- a/src/components/panels/BookmarksPanel.tsx
+++ b/src/components/panels/BookmarksPanel.tsx
@@ -359,7 +359,12 @@ export function BookmarksPanel() {
         observer?: ReturnType<typeof commandLog.observer>,
     ) => Effect.runPromise(prepareSyncPlan({ stackRootName, observer }))
 
+    const stackDialogMinHeight = (rowCount: number) =>
+        Math.max(18, rowCount + 14)
+
     const openStackPlan = async (stackRootName: string) => {
+        const preparingRows = stackRows(stackRootName)
+        const minHeight = stackDialogMinHeight(preparingRows.length)
         dialog.open(
             () => (
                 <StackPreparingModal
@@ -370,12 +375,12 @@ export function BookmarksPanel() {
             {
                 id: "bookmark-stack-sync-preparing",
                 title: [
-                    { text: "sync", style: "action" },
+                    { text: "Sync", style: "action" },
                     " preview for ",
                     { text: stackRootName, style: "target" },
                 ],
                 ...DIALOG_SIZE.confirmWide,
-                minHeight: 18,
+                minHeight,
                 closeOnEsc: false,
                 hints: [],
             },
@@ -394,12 +399,12 @@ export function BookmarksPanel() {
                 {
                     id: "bookmark-stack-sync-plan",
                     title: [
-                        { text: "sync", style: "action" },
+                        { text: "Sync", style: "action" },
                         " preview for ",
                         { text: stackRootName, style: "target" },
                     ],
                     ...DIALOG_SIZE.confirmWide,
-                    minHeight: 18,
+                    minHeight: stackDialogMinHeight(plan.rows.length),
                     closeOnEsc: false,
                     hints:
                         plan.effects.length > 0
@@ -462,11 +467,12 @@ export function BookmarksPanel() {
     }
 
     const openStackActions = (stackRootName: string) => {
+        const rows = stackRows(stackRootName)
         dialog.open(
             () => (
                 <StackActionsModal
                     stackRootName={stackRootName}
-                    rows={stackRows(stackRootName)}
+                    rows={rows}
                     prNumbers={bookmarkPrNumbers()}
                     actions={stackActionOptions(stackRootName)}
                 />
@@ -479,7 +485,7 @@ export function BookmarksPanel() {
                     { text: stackRootName, style: "target" },
                 ],
                 ...DIALOG_SIZE.confirmWide,
-                minHeight: 18,
+                minHeight: stackDialogMinHeight(rows.length),
                 hints: [
                     { key: "enter", label: "run" },
                     { key: "esc", label: "close" },

--- a/src/components/panels/BookmarksPanel.tsx
+++ b/src/components/panels/BookmarksPanel.tsx
@@ -2,7 +2,6 @@ import type { ScrollBoxRenderable, TextareaRenderable } from "@opentui/core"
 import { useKeyboard } from "@opentui/solid"
 import { Effect } from "effect"
 import fuzzysort from "fuzzysort"
-import { ptyToJson } from "ghostty-opentui"
 import {
     For,
     Show,
@@ -46,21 +45,16 @@ import { useSync } from "../../context/sync"
 import { useTheme } from "../../context/theme"
 import { buildBookmarkStackModel } from "../../stack/discovery"
 import type { BookmarkStackRow } from "../../stack/model"
-import { resolveAnsiForeground } from "../../theme/ansi"
 import { hasOriginDiff } from "../../utils/bookmark-origin-diff"
 import { createDoubleClickDetector } from "../../utils/double-click"
 import { FUZZY_THRESHOLD, scrollIntoView } from "../../utils/scroll"
-import { AnsiText } from "../AnsiText"
+import { BookmarkStackRowView } from "../BookmarkStackRowView"
 import { FilterInput } from "../FilterInput"
 import { Panel } from "../Panel"
 import { ActionMenuModal } from "../modals/ActionMenuModal"
 import { BookmarkNameModal } from "../modals/BookmarkNameModal"
 import { RevisionPickerModal } from "../modals/RevisionPickerModal"
-
-// biome-ignore lint/suspicious/noControlCharactersInRegex: intentional ANSI escape sequence
-const stripAnsi = (str: string) => str.replace(/\x1b\[[0-9;]*m/g, "")
-
-const emptyDescriptionPrefix = "(empty) "
+import { StackActionsModal } from "../modals/StackActionsModal"
 
 type BookmarkRow = BookmarkStackRow<Bookmark>
 
@@ -98,7 +92,7 @@ export function BookmarksPanel() {
     const commandLog = useCommandLog()
     const dialog = useDialog()
     const status = useStatus()
-    const { colors, mode } = useTheme()
+    const { colors } = useTheme()
     const { refresh } = useSync()
 
     const runOperation = async (
@@ -169,28 +163,6 @@ export function BookmarksPanel() {
 
     const isFocused = () => focus.isPanel("refs")
     const localBookmarks = () => bookmarks().filter((b) => b.isLocal)
-    const inlineAnsiSpans = (content: string, defaultFg?: string) => {
-        const spans =
-            ptyToJson(content, { cols: 9999, rows: 1 }).lines[0]?.spans ?? []
-        return spans
-            .filter((span) => span.text.length > 0)
-            .map((span) => ({
-                text: span.text,
-                fg: resolveAnsiForeground({
-                    fg: span.fg,
-                    mode: mode(),
-                    text: colors().text,
-                    textMuted: colors().textMuted,
-                    defaultFg,
-                }),
-                bg: span.bg ?? undefined,
-            }))
-    }
-    const bookmarkNameFg = (bookmark: Bookmark, defaultFg?: string) =>
-        inlineAnsiSpans(bookmark.nameDisplay || bookmark.name, defaultFg).at(-1)
-            ?.fg ??
-        defaultFg ??
-        colors().text
     const activeLocalBookmarks = createMemo(() =>
         visibleBookmarks().filter((b) => b.isLocal && b.changeId),
     )
@@ -381,48 +353,64 @@ export function BookmarksPanel() {
         return row.stackKeys[0]
     })
 
+    const stackActionOptions = (stackRootName: string) => [
+        {
+            key: "s",
+            mutedPrefix: "stack ",
+            label: "submit --dry-run",
+            onSelect: () =>
+                status.show(
+                    `Stack submit dry-run for ${stackRootName} is not implemented yet.`,
+                ),
+        },
+        {
+            key: "S",
+            mutedPrefix: "stack ",
+            label: "submit",
+            onSelect: () =>
+                status.show(
+                    `Stack submit for ${stackRootName} is not implemented yet.`,
+                ),
+        },
+        {
+            key: "f",
+            mutedPrefix: "stack ",
+            label: "sync --dry-run",
+            onSelect: () =>
+                status.show(
+                    `Stack sync dry-run for ${stackRootName} is not implemented yet.`,
+                ),
+        },
+        {
+            key: "F",
+            mutedPrefix: "stack ",
+            label: "sync",
+            onSelect: () =>
+                status.show(
+                    `Stack sync for ${stackRootName} is not implemented yet.`,
+                ),
+        },
+    ]
+
+    const stackRows = (stackRootName: string) => {
+        const rows = displayBookmarkRows().filter((row) =>
+            row.stackKeys.includes(stackRootName),
+        )
+        const minDepth = Math.min(...rows.map((row) => row.depth))
+        return rows.map((row) => ({
+            ...row,
+            depth: Math.max(0, row.depth - minDepth),
+        }))
+    }
+
     const openStackActions = (stackRootName: string) => {
         dialog.open(
             () => (
-                <ActionMenuModal
-                    options={[
-                        {
-                            key: "s",
-                            mutedPrefix: "stack ",
-                            label: "submit --dry-run",
-                            onSelect: () =>
-                                status.show(
-                                    `Stack submit dry-run for ${stackRootName} is not implemented yet.`,
-                                ),
-                        },
-                        {
-                            key: "S",
-                            mutedPrefix: "stack ",
-                            label: "submit",
-                            onSelect: () =>
-                                status.show(
-                                    `Stack submit for ${stackRootName} is not implemented yet.`,
-                                ),
-                        },
-                        {
-                            key: "f",
-                            mutedPrefix: "stack ",
-                            label: "sync --dry-run",
-                            onSelect: () =>
-                                status.show(
-                                    `Stack sync dry-run for ${stackRootName} is not implemented yet.`,
-                                ),
-                        },
-                        {
-                            key: "F",
-                            mutedPrefix: "stack ",
-                            label: "sync",
-                            onSelect: () =>
-                                status.show(
-                                    `Stack sync for ${stackRootName} is not implemented yet.`,
-                                ),
-                        },
-                    ]}
+                <StackActionsModal
+                    stackRootName={stackRootName}
+                    rows={stackRows(stackRootName)}
+                    prNumbers={bookmarkPrNumbers()}
+                    actions={stackActionOptions(stackRootName)}
                 />
             ),
             {
@@ -432,8 +420,11 @@ export function BookmarksPanel() {
                     " options for ",
                     { text: stackRootName, style: "target" },
                 ],
-                ...DIALOG_SIZE.confirm,
-                hints: [{ key: "enter", label: "run" }],
+                ...DIALOG_SIZE.confirmWide,
+                hints: [
+                    { key: "enter", label: "run" },
+                    { key: "esc", label: "close" },
+                ],
             },
         )
     }
@@ -1200,236 +1191,15 @@ export function BookmarksPanel() {
                                                         : 1
                                                 }
                                             >
-                                                <box
-                                                    flexDirection="row"
-                                                    flexGrow={1}
-                                                    overflow="hidden"
-                                                >
-                                                    <box
-                                                        flexShrink={0}
-                                                        overflow="hidden"
-                                                    >
-                                                        <text wrapMode="none">
-                                                            <Show
-                                                                when={
-                                                                    row.depth >
-                                                                    0
-                                                                }
-                                                            >
-                                                                <span
-                                                                    style={{
-                                                                        fg: colors()
-                                                                            .textMuted,
-                                                                    }}
-                                                                >
-                                                                    {"  ".repeat(
-                                                                        Math.max(
-                                                                            0,
-                                                                            row.depth -
-                                                                                1,
-                                                                        ),
-                                                                    )}
-                                                                    ↳{" "}
-                                                                </span>
-                                                            </Show>
-                                                            <For
-                                                                each={inlineAnsiSpans(
-                                                                    bookmark.nameDisplay ||
-                                                                        bookmark.name,
-                                                                    showSelection()
-                                                                        ? colors()
-                                                                              .selectionText
-                                                                        : undefined,
-                                                                )}
-                                                            >
-                                                                {(span) => (
-                                                                    <span
-                                                                        style={{
-                                                                            fg: span.fg,
-                                                                            bg: span.bg,
-                                                                        }}
-                                                                    >
-                                                                        {
-                                                                            span.text
-                                                                        }
-                                                                    </span>
-                                                                )}
-                                                            </For>
-                                                            <Show
-                                                                when={
-                                                                    bookmark.isLocal &&
-                                                                    originChangedBookmarkNames().has(
-                                                                        bookmark.name,
-                                                                    )
-                                                                }
-                                                            >
-                                                                <span
-                                                                    style={{
-                                                                        fg: bookmarkNameFg(
-                                                                            bookmark,
-                                                                            showSelection()
-                                                                                ? colors()
-                                                                                      .selectionText
-                                                                                : undefined,
-                                                                        ),
-                                                                    }}
-                                                                >
-                                                                    *
-                                                                </span>
-                                                            </Show>
-                                                            <Show
-                                                                when={prNumber()}
-                                                            >
-                                                                <span
-                                                                    style={{
-                                                                        fg: colors()
-                                                                            .textMuted,
-                                                                    }}
-                                                                >
-                                                                    {` #${prNumber()}`}
-                                                                </span>
-                                                            </Show>
-                                                            <Show
-                                                                when={
-                                                                    !isDeleted()
-                                                                }
-                                                                fallback={
-                                                                    <span
-                                                                        style={{
-                                                                            fg: colors()
-                                                                                .error,
-                                                                        }}
-                                                                    >
-                                                                        {
-                                                                            " –deleted "
-                                                                        }
-                                                                    </span>
-                                                                }
-                                                            >
-                                                                <span
-                                                                    style={{
-                                                                        fg: colors()
-                                                                            .textMuted,
-                                                                    }}
-                                                                >
-                                                                    {" "}
-                                                                </span>
-                                                                <For
-                                                                    each={inlineAnsiSpans(
-                                                                        bookmark.changeIdDisplay ||
-                                                                            bookmark.changeId,
-                                                                        showSelection()
-                                                                            ? colors()
-                                                                                  .selectionText
-                                                                            : colors()
-                                                                                  .textMuted,
-                                                                    )}
-                                                                >
-                                                                    {(span) => (
-                                                                        <span
-                                                                            style={{
-                                                                                fg: span.fg,
-                                                                                bg: span.bg,
-                                                                            }}
-                                                                        >
-                                                                            {
-                                                                                span.text
-                                                                            }
-                                                                        </span>
-                                                                    )}
-                                                                </For>
-                                                                <span
-                                                                    style={{
-                                                                        fg: colors()
-                                                                            .textMuted,
-                                                                    }}
-                                                                >
-                                                                    {" "}
-                                                                </span>
-                                                            </Show>
-                                                            <Show
-                                                                when={
-                                                                    showRemoteOnly() &&
-                                                                    bookmark.remote
-                                                                }
-                                                            >
-                                                                <span
-                                                                    style={{
-                                                                        fg: colors()
-                                                                            .textMuted,
-                                                                    }}
-                                                                >
-                                                                    @
-                                                                    {
-                                                                        bookmark.remote
-                                                                    }{" "}
-                                                                </span>
-                                                            </Show>
-                                                        </text>
-                                                    </box>
-                                                    <Show when={!isDeleted()}>
-                                                        <box
-                                                            flexDirection="row"
-                                                            flexGrow={1}
-                                                            overflow="hidden"
-                                                        >
-                                                            <Show
-                                                                when={stripAnsi(
-                                                                    bookmark.descriptionDisplay,
-                                                                ).startsWith(
-                                                                    emptyDescriptionPrefix,
-                                                                )}
-                                                                fallback={
-                                                                    <text
-                                                                        fg={
-                                                                            colors()
-                                                                                .textMuted
-                                                                        }
-                                                                        content={
-                                                                            bookmark.description
-                                                                        }
-                                                                        wrapMode="none"
-                                                                    />
-                                                                }
-                                                            >
-                                                                <box
-                                                                    width={
-                                                                        emptyDescriptionPrefix.length
-                                                                    }
-                                                                    flexShrink={
-                                                                        0
-                                                                    }
-                                                                >
-                                                                    <text
-                                                                        fg={
-                                                                            colors()
-                                                                                .success
-                                                                        }
-                                                                        content={
-                                                                            emptyDescriptionPrefix
-                                                                        }
-                                                                        wrapMode="none"
-                                                                    />
-                                                                </box>
-                                                                <box
-                                                                    flexGrow={1}
-                                                                    overflow="hidden"
-                                                                >
-                                                                    <text
-                                                                        fg={
-                                                                            colors()
-                                                                                .textMuted
-                                                                        }
-                                                                        content={bookmark.description.slice(
-                                                                            emptyDescriptionPrefix.length,
-                                                                        )}
-                                                                        wrapMode="none"
-                                                                    />
-                                                                </box>
-                                                            </Show>
-                                                        </box>
-                                                    </Show>
-                                                </box>
+                                                <BookmarkStackRowView
+                                                    row={row}
+                                                    selected={showSelection()}
+                                                    prNumber={prNumber()}
+                                                    showOriginChanged={originChangedBookmarkNames().has(
+                                                        bookmark.name,
+                                                    )}
+                                                    showRemote={showRemoteOnly()}
+                                                />
                                             </box>
                                         </>
                                     )

--- a/src/components/panels/BookmarksPanel.tsx
+++ b/src/components/panels/BookmarksPanel.tsx
@@ -22,6 +22,7 @@ import {
 } from "../../commander/bookmarks"
 import { withCommandObserver } from "../../commander/executor"
 import {
+    type GitHubPullRequestSummary,
     ghBrowseCommit,
     ghListPullRequestsByHead,
     ghPrCreateWeb,
@@ -44,7 +45,8 @@ import { useStatus } from "../../context/status"
 import { useSync } from "../../context/sync"
 import { useTheme } from "../../context/theme"
 import { buildBookmarkStackModel } from "../../stack/discovery"
-import type { BookmarkStackRow } from "../../stack/model"
+import type { BookmarkStackModel, BookmarkStackRow } from "../../stack/model"
+import { buildSubmitPlanSync, buildSyncPlanSync } from "../../stack/planner"
 import { hasOriginDiff } from "../../utils/bookmark-origin-diff"
 import { createDoubleClickDetector } from "../../utils/double-click"
 import { FUZZY_THRESHOLD, scrollIntoView } from "../../utils/scroll"
@@ -55,6 +57,7 @@ import { ActionMenuModal } from "../modals/ActionMenuModal"
 import { BookmarkNameModal } from "../modals/BookmarkNameModal"
 import { RevisionPickerModal } from "../modals/RevisionPickerModal"
 import { StackActionsModal } from "../modals/StackActionsModal"
+import { StackPlanModal } from "../modals/StackPlanModal"
 
 type BookmarkRow = BookmarkStackRow<Bookmark>
 
@@ -205,9 +208,18 @@ export function BookmarksPanel() {
     const [filterSelectedIndex, setFilterSelectedIndex] = createSignal(0)
     const [showRemoteOnly, setShowRemoteOnly] = createSignal(false)
     const [remoteSelectedIndex, setRemoteSelectedIndex] = createSignal(0)
-    const [bookmarkPrNumbers, setBookmarkPrNumbers] = createSignal<
-        ReadonlyMap<string, number>
+    const [pullRequestsByHead, setPullRequestsByHead] = createSignal<
+        ReadonlyMap<string, GitHubPullRequestSummary>
     >(new Map())
+    const bookmarkPrNumbers = createMemo(
+        () =>
+            new Map(
+                [...pullRequestsByHead()].map(([head, pull]) => [
+                    head,
+                    pull.number,
+                ]),
+            ),
+    )
     const [prMetadataRefreshToken, setPrMetadataRefreshToken] = createSignal(0)
     const refreshPrMetadataAfterPrCreateWeb = () => {
         setTimeout(() => setPrMetadataRefreshToken((token) => token + 1), 15000)
@@ -248,7 +260,7 @@ export function BookmarksPanel() {
             .map((bookmark) => bookmark.name)
             .sort()
         if (names.length === 0) {
-            setBookmarkPrNumbers(new Map())
+            setPullRequestsByHead(new Map())
             return
         }
 
@@ -256,15 +268,10 @@ export function BookmarksPanel() {
         ghListPullRequestsByHead(names)
             .then((pullsByHead) => {
                 if (cancelled) return
-                const next = new Map<string, number>()
-                for (const name of names) {
-                    const pull = pullsByHead.get(name)
-                    if (pull) next.set(name, pull.number)
-                }
-                setBookmarkPrNumbers(next)
+                setPullRequestsByHead(pullsByHead)
             })
             .catch(() => {
-                if (!cancelled) setBookmarkPrNumbers(new Map())
+                if (!cancelled) setPullRequestsByHead(new Map())
             })
 
         onCleanup(() => {
@@ -293,7 +300,23 @@ export function BookmarksPanel() {
         return visibleLocalBookmarks()
     })
 
-    const displayBookmarkRows = createMemo<BookmarkRow[]>(() => {
+    const displayBookmarkStackModel = createMemo<
+        BookmarkStackModel<Bookmark> | undefined
+    >(() => {
+        if (hasActiveFilter() || showRemoteOnly()) return undefined
+        return Effect.runSync(
+            buildBookmarkStackModel({
+                commits: commits().map((commit) => ({
+                    commitId: commit.commitId,
+                    parentCommitIds: commit.parentCommitIds ?? [],
+                    immutable: commit.immutable,
+                })),
+                bookmarks: displayBookmarks(),
+            }),
+        )
+    })
+
+    const displayBookmarkRows = createMemo<readonly BookmarkRow[]>(() => {
         const source = displayBookmarks()
         if (hasActiveFilter() || showRemoteOnly()) {
             return source.map((bookmark) => ({
@@ -303,17 +326,7 @@ export function BookmarksPanel() {
             }))
         }
 
-        const model = Effect.runSync(
-            buildBookmarkStackModel({
-                commits: commits().map((commit) => ({
-                    commitId: commit.commitId,
-                    parentCommitIds: commit.parentCommitIds ?? [],
-                    immutable: commit.immutable,
-                })),
-                bookmarks: source,
-            }),
-        )
-        return model.rows
+        return displayBookmarkStackModel()?.rows ?? []
     })
 
     const currentBookmarks = () =>
@@ -353,15 +366,73 @@ export function BookmarksPanel() {
         return row.stackKeys[0]
     })
 
+    const remoteBookmarksByName = () =>
+        new Map(
+            remoteBookmarks()
+                .filter((bookmark) => !bookmark.isLocal)
+                .map((bookmark) => [bookmark.name, bookmark]),
+        )
+
+    const openStackPlan = (kind: "submit" | "sync", stackRootName: string) => {
+        const stackModel = displayBookmarkStackModel()
+        if (!stackModel) return
+        const plan =
+            kind === "submit"
+                ? buildSubmitPlanSync({
+                      stackRootName,
+                      stackModel,
+                      pullRequestsByHead: pullRequestsByHead(),
+                      remoteBookmarksByName: remoteBookmarksByName(),
+                  })
+                : buildSyncPlanSync({
+                      stackRootName,
+                      stackModel,
+                      pullRequestsByHead: pullRequestsByHead(),
+                      remoteBookmarksByName: remoteBookmarksByName(),
+                  })
+        dialog.open(
+            () => (
+                <StackPlanModal
+                    plan={plan}
+                    onApply={() =>
+                        status.show(
+                            kind === "submit"
+                                ? `Stack submit for ${stackRootName} is not implemented yet.`
+                                : `Stack sync for ${stackRootName} is not implemented yet.`,
+                        )
+                    }
+                    onBack={() => openStackActions(stackRootName)}
+                />
+            ),
+            {
+                id: `bookmark-stack-${kind}-plan`,
+                title: [
+                    {
+                        text:
+                            kind === "submit"
+                                ? "Submit preview"
+                                : "Sync preview",
+                        style: "action",
+                    },
+                    " for ",
+                    { text: stackRootName, style: "target" },
+                ],
+                ...DIALOG_SIZE.confirmWide,
+                closeOnEsc: false,
+                hints: [
+                    { key: "enter", label: "apply" },
+                    { key: "esc", label: "back" },
+                ],
+            },
+        )
+    }
+
     const stackActionOptions = (stackRootName: string) => [
         {
             key: "s",
             mutedPrefix: "stack ",
             label: "submit --dry-run",
-            onSelect: () =>
-                status.show(
-                    `Stack submit dry-run for ${stackRootName} is not implemented yet.`,
-                ),
+            onSelect: () => openStackPlan("submit", stackRootName),
         },
         {
             key: "S",
@@ -376,10 +447,7 @@ export function BookmarksPanel() {
             key: "f",
             mutedPrefix: "stack ",
             label: "sync --dry-run",
-            onSelect: () =>
-                status.show(
-                    `Stack sync dry-run for ${stackRootName} is not implemented yet.`,
-                ),
+            onSelect: () => openStackPlan("sync", stackRootName),
         },
         {
             key: "F",

--- a/src/components/panels/BookmarksPanel.tsx
+++ b/src/components/panels/BookmarksPanel.tsx
@@ -26,6 +26,7 @@ import {
     ghBrowseCommit,
     ghListPullRequestsByHead,
     ghPrCreateWeb,
+    ghPrViewWeb,
 } from "../../commander/github"
 import {
     type OperationResult,
@@ -142,6 +143,14 @@ export function BookmarksPanel() {
             }
         } catch {
             // fall through to PR open
+        }
+
+        const knownPrNumber = bookmarkPrNumbers().get(bookmark.name)
+        if (knownPrNumber) {
+            const observer = commandLog.observer()
+            const viewResult = await ghPrViewWeb(knownPrNumber, { observer })
+            commandLog.addEntry(viewResult)
+            return
         }
 
         await loadRemoteBookmarks()

--- a/src/components/panels/BookmarksPanel.tsx
+++ b/src/components/panels/BookmarksPanel.tsx
@@ -22,7 +22,11 @@ import {
     jjBookmarkSet,
 } from "../../commander/bookmarks"
 import { withCommandObserver } from "../../commander/executor"
-import { ghBrowseCommit, ghPrCreateWeb } from "../../commander/github"
+import {
+    ghBrowseCommit,
+    ghListPullRequestsByHead,
+    ghPrCreateWeb,
+} from "../../commander/github"
 import {
     type OperationResult,
     isImmutableError,
@@ -157,6 +161,9 @@ export function BookmarksPanel() {
         const observer = commandLog.observer()
         const prResult = await ghPrCreateWeb(bookmark.name, { observer })
         commandLog.addEntry(prResult)
+        if (prResult.success) {
+            refreshPrMetadataAfterPrCreateWeb()
+        }
     }
 
     const isFocused = () => focus.isPanel("refs")
@@ -225,6 +232,15 @@ export function BookmarksPanel() {
     const [filterSelectedIndex, setFilterSelectedIndex] = createSignal(0)
     const [showRemoteOnly, setShowRemoteOnly] = createSignal(false)
     const [remoteSelectedIndex, setRemoteSelectedIndex] = createSignal(0)
+    const [bookmarkPrNumbers, setBookmarkPrNumbers] = createSignal<
+        ReadonlyMap<string, number>
+    >(new Map())
+    const [prMetadataRefreshToken, setPrMetadataRefreshToken] = createSignal(0)
+    const refreshPrMetadataAfterPrCreateWeb = () => {
+        setTimeout(() => setPrMetadataRefreshToken((token) => token + 1), 15000)
+        setTimeout(() => setPrMetadataRefreshToken((token) => token + 1), 30000)
+        setTimeout(() => setPrMetadataRefreshToken((token) => token + 1), 60000)
+    }
     const selectedBookmarkHasOriginDiff = createMemo(() => {
         if (showRemoteOnly()) return false
         const bookmark = selectedBookmark()
@@ -252,6 +268,36 @@ export function BookmarksPanel() {
     const hasActiveFilter = createMemo(
         () => activeFilterQuery().trim().length > 0,
     )
+
+    createEffect(() => {
+        prMetadataRefreshToken()
+        const names = activeLocalBookmarks()
+            .map((bookmark) => bookmark.name)
+            .sort()
+        if (names.length === 0) {
+            setBookmarkPrNumbers(new Map())
+            return
+        }
+
+        let cancelled = false
+        ghListPullRequestsByHead(names)
+            .then((pullsByHead) => {
+                if (cancelled) return
+                const next = new Map<string, number>()
+                for (const name of names) {
+                    const pull = pullsByHead.get(name)
+                    if (pull) next.set(name, pull.number)
+                }
+                setBookmarkPrNumbers(next)
+            })
+            .catch(() => {
+                if (!cancelled) setBookmarkPrNumbers(new Map())
+            })
+
+        onCleanup(() => {
+            cancelled = true
+        })
+    })
 
     const filteredBookmarks = createMemo(() => {
         const q = activeFilterQuery().trim()
@@ -1002,6 +1048,8 @@ export function BookmarksPanel() {
                                         handleDoubleClick()
                                     }
                                     const isDeleted = () => !bookmark.changeId
+                                    const prNumber = () =>
+                                        bookmarkPrNumbers().get(bookmark.name)
                                     const isInActiveStack = () =>
                                         Boolean(
                                             activeStackKey() &&
@@ -1112,6 +1160,18 @@ export function BookmarksPanel() {
                                                                     }}
                                                                 >
                                                                     *
+                                                                </span>
+                                                            </Show>
+                                                            <Show
+                                                                when={prNumber()}
+                                                            >
+                                                                <span
+                                                                    style={{
+                                                                        fg: colors()
+                                                                            .textMuted,
+                                                                    }}
+                                                                >
+                                                                    {` #${prNumber()}`}
                                                                 </span>
                                                             </Show>
                                                             <Show

--- a/src/components/panels/BookmarksPanel.tsx
+++ b/src/components/panels/BookmarksPanel.tsx
@@ -374,11 +374,6 @@ export function BookmarksPanel() {
             ),
             {
                 id: "bookmark-stack-sync-preparing",
-                title: [
-                    { text: "Sync", style: "action" },
-                    " preview for ",
-                    { text: stackRootName, style: "target" },
-                ],
                 ...DIALOG_SIZE.confirmWide,
                 minHeight,
                 closeOnEsc: false,
@@ -409,8 +404,8 @@ export function BookmarksPanel() {
                     hints:
                         plan.effects.length > 0
                             ? [
-                                  { key: "enter", label: "apply" },
                                   { key: "esc", label: "back" },
+                                  { key: "enter", label: "apply" },
                               ]
                             : [{ key: "esc", label: "back" }],
                 },
@@ -486,10 +481,7 @@ export function BookmarksPanel() {
                 ],
                 ...DIALOG_SIZE.confirmWide,
                 minHeight: stackDialogMinHeight(rows.length),
-                hints: [
-                    { key: "enter", label: "run" },
-                    { key: "esc", label: "close" },
-                ],
+                hints: [{ key: "enter", label: "run" }],
             },
         )
     }

--- a/src/components/panels/BookmarksPanel.tsx
+++ b/src/components/panels/BookmarksPanel.tsx
@@ -1,5 +1,6 @@
 import type { ScrollBoxRenderable, TextareaRenderable } from "@opentui/core"
 import { useKeyboard } from "@opentui/solid"
+import { Effect } from "effect"
 import fuzzysort from "fuzzysort"
 import { ptyToJson } from "ghostty-opentui"
 import {
@@ -39,6 +40,8 @@ import { useKeybind } from "../../context/keybind"
 import { useStatus } from "../../context/status"
 import { useSync } from "../../context/sync"
 import { useTheme } from "../../context/theme"
+import { buildBookmarkStackModel } from "../../stack/discovery"
+import type { BookmarkStackRow } from "../../stack/model"
 import { resolveAnsiForeground } from "../../theme/ansi"
 import { hasOriginDiff } from "../../utils/bookmark-origin-diff"
 import { createDoubleClickDetector } from "../../utils/double-click"
@@ -53,6 +56,8 @@ import { RevisionPickerModal } from "../modals/RevisionPickerModal"
 const stripAnsi = (str: string) => str.replace(/\x1b\[[0-9;]*m/g, "")
 
 const emptyDescriptionPrefix = "(empty) "
+
+type BookmarkRow = BookmarkStackRow<Bookmark>
 
 export function BookmarksPanel() {
     const {
@@ -178,19 +183,6 @@ export function BookmarksPanel() {
             ?.fg ??
         defaultFg ??
         colors().text
-    const remoteBookmarkNames = createMemo(() => {
-        const names = new Set<string>()
-        for (const bookmark of remoteBookmarks()) {
-            if (!bookmark.isLocal) {
-                names.add(bookmark.name)
-            }
-        }
-        return names
-    })
-    const canSplitByUntracked = createMemo(
-        () => !remoteBookmarksLoading() && !remoteBookmarksError(),
-    )
-
     const activeLocalBookmarks = createMemo(() =>
         visibleBookmarks().filter((b) => b.isLocal && b.changeId),
     )
@@ -214,14 +206,6 @@ export function BookmarksPanel() {
     })
     const deletedLocalBookmarks = createMemo(() =>
         visibleBookmarks().filter((b) => b.isLocal && !b.changeId),
-    )
-    const localOnlyBookmarks = createMemo(() =>
-        activeLocalBookmarks().filter(
-            (b) => !remoteBookmarkNames().has(b.name),
-        ),
-    )
-    const trackedLocalBookmarks = createMemo(() =>
-        activeLocalBookmarks().filter((b) => remoteBookmarkNames().has(b.name)),
     )
     const remoteOnlyBookmarks = createMemo(() => {
         const localNames = new Set(localBookmarks().map((b) => b.name))
@@ -287,17 +271,36 @@ export function BookmarksPanel() {
     const displayBookmarks = createMemo(() => {
         if (hasActiveFilter()) return filteredBookmarks()
         if (showRemoteOnly()) return remoteOnlyBookmarks()
-        if (!canSplitByUntracked()) return visibleLocalBookmarks()
-        return [
-            ...localOnlyBookmarks(),
-            ...trackedLocalBookmarks(),
-            ...deletedLocalBookmarks(),
-        ]
+        return visibleLocalBookmarks()
     })
 
-    const currentBookmarks = () => displayBookmarks()
+    const displayBookmarkRows = createMemo<BookmarkRow[]>(() => {
+        const source = displayBookmarks()
+        if (hasActiveFilter() || showRemoteOnly()) {
+            return source.map((bookmark) => ({
+                bookmark,
+                depth: 0,
+                stackKeys: [],
+            }))
+        }
 
-    const listTotalRows = createMemo(() => displayBookmarks().length)
+        const model = Effect.runSync(
+            buildBookmarkStackModel({
+                commits: commits().map((commit) => ({
+                    commitId: commit.commitId,
+                    parentCommitIds: commit.parentCommitIds ?? [],
+                    immutable: commit.immutable,
+                })),
+                bookmarks: source,
+            }),
+        )
+        return model.rows
+    })
+
+    const currentBookmarks = () =>
+        displayBookmarkRows().map((row) => row.bookmark)
+
+    const listTotalRows = createMemo(() => displayBookmarkRows().length)
     const canPageBookmarks = createMemo(
         () => !showRemoteOnly() && !hasActiveFilter() && bookmarksHasMore(),
     )
@@ -307,24 +310,26 @@ export function BookmarksPanel() {
         if (showRemoteOnly()) return remoteSelectedIndex()
         const selected = selectedBookmark()
         if (!selected) return 0
-        const idx = displayBookmarks().findIndex(
+        const idx = currentBookmarks().findIndex(
             (b) => b.name === selected.name,
         )
         return idx >= 0 ? idx : 0
     })
 
     const currentSelectedIndex = () => displaySelectedIndex()
-    const localOnlySeparatorIndex = createMemo(
-        () => localOnlyBookmarks().length,
-    )
-    const showUntrackedSeparator = createMemo(
-        () =>
-            !hasActiveFilter() &&
-            !showRemoteOnly() &&
-            canSplitByUntracked() &&
-            localOnlyBookmarks().length > 0 &&
-            trackedLocalBookmarks().length + deletedLocalBookmarks().length > 0,
-    )
+    const activeStackKey = createMemo(() => {
+        if (!isFocused()) return undefined
+        const row = displayBookmarkRows()[currentSelectedIndex()]
+        if (!row) return undefined
+        if (
+            commits().find(
+                (commit) => commit.commitId === row.bookmark.commitId,
+            )?.immutable
+        ) {
+            return undefined
+        }
+        return row.stackKeys[0]
+    })
 
     createEffect(
         on(
@@ -377,7 +382,7 @@ export function BookmarksPanel() {
     )
 
     const selectNextBookmarkInView = () => {
-        const max = displayBookmarks().length - 1
+        const max = currentBookmarks().length - 1
         if (max < 0) return
         if (hasActiveFilter()) {
             setFilterSelectedIndex((i) => Math.min(max, i + 1))
@@ -388,7 +393,7 @@ export function BookmarksPanel() {
             return
         }
         const nextIndex = Math.min(max, displaySelectedIndex() + 1)
-        const nextBookmark = displayBookmarks()[nextIndex]
+        const nextBookmark = currentBookmarks()[nextIndex]
         if (!nextBookmark) return
         const localIndex = localBookmarks().findIndex(
             (b) => b.name === nextBookmark.name,
@@ -408,7 +413,7 @@ export function BookmarksPanel() {
             return
         }
         const prevIndex = Math.max(0, displaySelectedIndex() - 1)
-        const prevBookmark = displayBookmarks()[prevIndex]
+        const prevBookmark = currentBookmarks()[prevIndex]
         if (!prevBookmark) return
         const localIndex = localBookmarks().findIndex(
             (b) => b.name === prevBookmark.name,
@@ -963,8 +968,9 @@ export function BookmarksPanel() {
                                 backgroundColor: colors().background,
                             }}
                         >
-                            <For each={currentBookmarks()}>
-                                {(bookmark, index) => {
+                            <For each={displayBookmarkRows()}>
+                                {(row, index) => {
+                                    const bookmark = row.bookmark
                                     const isSelected = () =>
                                         index() === currentSelectedIndex()
                                     const showSelection = () =>
@@ -996,27 +1002,20 @@ export function BookmarksPanel() {
                                         handleDoubleClick()
                                     }
                                     const isDeleted = () => !bookmark.changeId
+                                    const isInActiveStack = () =>
+                                        Boolean(
+                                            activeStackKey() &&
+                                                row.stackKeys.includes(
+                                                    activeStackKey() ?? "",
+                                                ),
+                                        )
+                                    const isMutedByActiveStack = () =>
+                                        Boolean(
+                                            activeStackKey() &&
+                                                !isInActiveStack(),
+                                        )
                                     return (
                                         <>
-                                            <Show
-                                                when={
-                                                    showUntrackedSeparator() &&
-                                                    index() ===
-                                                        localOnlySeparatorIndex()
-                                                }
-                                            >
-                                                <box
-                                                    height={1}
-                                                    overflow="hidden"
-                                                >
-                                                    <text
-                                                        fg={colors().textMuted}
-                                                        wrapMode="none"
-                                                    >
-                                                        {"─".repeat(200)}
-                                                    </text>
-                                                </box>
-                                            </Show>
                                             <box
                                                 width="100%"
                                                 height={1}
@@ -1032,6 +1031,11 @@ export function BookmarksPanel() {
                                                 }
                                                 overflow="hidden"
                                                 onMouseDown={handleMouseDown}
+                                                opacity={
+                                                    isMutedByActiveStack()
+                                                        ? 0.6
+                                                        : 1
+                                                }
                                             >
                                                 <box
                                                     flexDirection="row"
@@ -1043,6 +1047,28 @@ export function BookmarksPanel() {
                                                         overflow="hidden"
                                                     >
                                                         <text wrapMode="none">
+                                                            <Show
+                                                                when={
+                                                                    row.depth >
+                                                                    0
+                                                                }
+                                                            >
+                                                                <span
+                                                                    style={{
+                                                                        fg: colors()
+                                                                            .textMuted,
+                                                                    }}
+                                                                >
+                                                                    {"  ".repeat(
+                                                                        Math.max(
+                                                                            0,
+                                                                            row.depth -
+                                                                                1,
+                                                                        ),
+                                                                    )}
+                                                                    ↳{" "}
+                                                                </span>
+                                                            </Show>
                                                             <For
                                                                 each={inlineAnsiSpans(
                                                                     bookmark.nameDisplay ||

--- a/src/components/panels/BookmarksPanel.tsx
+++ b/src/components/panels/BookmarksPanel.tsx
@@ -22,9 +22,7 @@ import {
 } from "../../commander/bookmarks"
 import { withCommandObserver } from "../../commander/executor"
 import {
-    type GitHubPullRequestSummary,
     ghBrowseCommit,
-    ghListPullRequestsByHead,
     ghPrCreateWeb,
     ghPrViewWeb,
 } from "../../commander/github"
@@ -94,6 +92,9 @@ export function BookmarksPanel() {
         loadRemoteBookmarks,
         activeBookmarkDiff,
         enterBookmarkDiffView,
+        pullRequestsByHead,
+        bookmarkPrNumbers,
+        refreshPullRequestMetadata,
     } = useSync()
     const focus = useFocus()
     const command = useCommand()
@@ -174,7 +175,7 @@ export function BookmarksPanel() {
         const prResult = await ghPrCreateWeb(bookmark.name, { observer })
         commandLog.addEntry(prResult)
         if (prResult.success) {
-            refreshPrMetadataAfterPrCreateWeb()
+            refreshPullRequestMetadata()
         }
     }
 
@@ -222,24 +223,6 @@ export function BookmarksPanel() {
     const [filterSelectedIndex, setFilterSelectedIndex] = createSignal(0)
     const [showRemoteOnly, setShowRemoteOnly] = createSignal(false)
     const [remoteSelectedIndex, setRemoteSelectedIndex] = createSignal(0)
-    const [pullRequestsByHead, setPullRequestsByHead] = createSignal<
-        ReadonlyMap<string, GitHubPullRequestSummary>
-    >(new Map())
-    const bookmarkPrNumbers = createMemo(
-        () =>
-            new Map(
-                [...pullRequestsByHead()].map(([head, pull]) => [
-                    head,
-                    pull.number,
-                ]),
-            ),
-    )
-    const [prMetadataRefreshToken, setPrMetadataRefreshToken] = createSignal(0)
-    const refreshPrMetadataAfterPrCreateWeb = () => {
-        setTimeout(() => setPrMetadataRefreshToken((token) => token + 1), 15000)
-        setTimeout(() => setPrMetadataRefreshToken((token) => token + 1), 30000)
-        setTimeout(() => setPrMetadataRefreshToken((token) => token + 1), 60000)
-    }
     const selectedBookmarkHasOriginDiff = createMemo(() => {
         if (showRemoteOnly()) return false
         const bookmark = selectedBookmark()
@@ -267,31 +250,6 @@ export function BookmarksPanel() {
     const hasActiveFilter = createMemo(
         () => activeFilterQuery().trim().length > 0,
     )
-
-    createEffect(() => {
-        prMetadataRefreshToken()
-        const names = activeLocalBookmarks()
-            .map((bookmark) => bookmark.name)
-            .sort()
-        if (names.length === 0) {
-            setPullRequestsByHead(new Map())
-            return
-        }
-
-        let cancelled = false
-        ghListPullRequestsByHead(names)
-            .then((pullsByHead) => {
-                if (cancelled) return
-                setPullRequestsByHead(pullsByHead)
-            })
-            .catch(() => {
-                if (!cancelled) setPullRequestsByHead(new Map())
-            })
-
-        onCleanup(() => {
-            cancelled = true
-        })
-    })
 
     const filteredBookmarks = createMemo(() => {
         const q = activeFilterQuery().trim()
@@ -386,8 +344,8 @@ export function BookmarksPanel() {
         const observer = commandLog.observer()
         try {
             await Effect.runPromise(applyStackPlan(plan, { observer }))
-            refresh()
-            setPrMetadataRefreshToken((token) => token + 1)
+            await refresh()
+            refreshPullRequestMetadata()
         } catch (error) {
             commandLog.addEntry({
                 command: plan.applyCommand,

--- a/src/components/panels/BookmarksPanel.tsx
+++ b/src/components/panels/BookmarksPanel.tsx
@@ -465,10 +465,13 @@ export function BookmarksPanel() {
                     ],
                     ...DIALOG_SIZE.confirmWide,
                     closeOnEsc: false,
-                    hints: [
-                        { key: "enter", label: "apply" },
-                        { key: "esc", label: "back" },
-                    ],
+                    hints:
+                        plan.effects.length > 0
+                            ? [
+                                  { key: "enter", label: "apply" },
+                                  { key: "esc", label: "back" },
+                              ]
+                            : [{ key: "esc", label: "back" }],
                 },
             )
         } catch (error) {
@@ -489,6 +492,10 @@ export function BookmarksPanel() {
         const observer = commandLog.observer()
         try {
             const plan = await preparePlan(kind, stackRootName, observer)
+            if (plan.effects.length === 0) {
+                status.show("Nothing to do; stack is already in sync.")
+                return
+            }
             await applyPreparedPlan(plan)
         } catch (error) {
             commandLog.addEntry({

--- a/src/components/panels/BookmarksPanel.tsx
+++ b/src/components/panels/BookmarksPanel.tsx
@@ -35,6 +35,7 @@ import {
     jjNew,
 } from "../../commander/operations"
 import { getRevisionId } from "../../commander/types"
+import { featureFlags } from "../../feature-flags"
 import { useCommand } from "../../context/command"
 import { useCommandLog } from "../../context/commandlog"
 import { DIALOG_SIZE, useDialog } from "../../context/dialog"
@@ -101,6 +102,7 @@ export function BookmarksPanel() {
     const status = useStatus()
     const { colors } = useTheme()
     const { refresh } = useSync()
+    const githubStackingEnabled = featureFlags.githubStacking
 
     const runOperation = async (
         text: string,
@@ -272,6 +274,7 @@ export function BookmarksPanel() {
     const displayBookmarkStackModel = createMemo<
         BookmarkStackModel<Bookmark> | undefined
     >(() => {
+        if (!githubStackingEnabled()) return undefined
         if (hasActiveFilter() || showRemoteOnly()) return undefined
         return Effect.runSync(
             buildBookmarkStackModel({
@@ -287,7 +290,7 @@ export function BookmarksPanel() {
 
     const displayBookmarkRows = createMemo<readonly BookmarkRow[]>(() => {
         const source = displayBookmarks()
-        if (hasActiveFilter() || showRemoteOnly()) {
+        if (!githubStackingEnabled() || hasActiveFilter() || showRemoteOnly()) {
             return source.map((bookmark) => ({
                 bookmark,
                 depth: 0,
@@ -322,6 +325,7 @@ export function BookmarksPanel() {
         () => displayBookmarkRows()[currentSelectedIndex()],
     )
     const activeStackKey = createMemo(() => {
+        if (!githubStackingEnabled()) return undefined
         if (!isFocused()) return undefined
         const row = selectedBookmarkRow()
         if (!row) return undefined
@@ -513,6 +517,12 @@ export function BookmarksPanel() {
     }
 
     const openSelectedStack = async () => {
+        if (!githubStackingEnabled()) {
+            status.show(
+                "GitHub stacking is disabled. Run with KAJJI_ENABLE_STACKING=1 to enable it.",
+            )
+            return
+        }
         if (showRemoteOnly()) return
         const row = selectedBookmarkRow()
         if (!row) return
@@ -1118,15 +1128,19 @@ export function BookmarksPanel() {
                 )
             },
         },
-        {
-            id: "refs.bookmarks.stack",
-            title: "stack",
-            keybind: "bookmark_stack",
-            context: "refs.bookmarks",
-            type: "action",
-            panel: "refs",
-            onSelect: openSelectedStack,
-        },
+        ...(githubStackingEnabled()
+            ? [
+                  {
+                      id: "refs.bookmarks.stack",
+                      title: "stack",
+                      keybind: "bookmark_stack" as const,
+                      context: "refs.bookmarks" as const,
+                      type: "action" as const,
+                      panel: "refs" as const,
+                      onSelect: openSelectedStack,
+                  },
+              ]
+            : []),
         {
             id: "refs.bookmarks.diff_origin",
             title: "compare to origin",

--- a/src/components/panels/BookmarksPanel.tsx
+++ b/src/components/panels/BookmarksPanel.tsx
@@ -44,12 +44,9 @@ import { useStatus } from "../../context/status"
 import { useSync } from "../../context/sync"
 import { useTheme } from "../../context/theme"
 import { buildBookmarkStackModel } from "../../stack/discovery"
-import {
-    applyStackPlan,
-    prepareSubmitPlan,
-    prepareSyncPlan,
-} from "../../stack/executor"
+import { applyStackPlan, prepareSyncPlan } from "../../stack/executor"
 import type { BookmarkStackModel, BookmarkStackRow } from "../../stack/model"
+import { readPersistedStackState } from "../../stack/state"
 import { hasOriginDiff } from "../../utils/bookmark-origin-diff"
 import { createDoubleClickDetector } from "../../utils/double-click"
 import { FUZZY_THRESHOLD, scrollIntoView } from "../../utils/scroll"
@@ -358,47 +355,33 @@ export function BookmarksPanel() {
     }
 
     const preparePlan = async (
-        kind: "submit" | "sync",
         stackRootName: string,
         observer?: ReturnType<typeof commandLog.observer>,
-    ) =>
-        Effect.runPromise(
-            kind === "submit"
-                ? prepareSubmitPlan({ stackRootName, observer })
-                : prepareSyncPlan({ stackRootName, observer }),
-        )
+    ) => Effect.runPromise(prepareSyncPlan({ stackRootName, observer }))
 
-    const openStackPlan = async (
-        kind: "submit" | "sync",
-        stackRootName: string,
-    ) => {
+    const openStackPlan = async (stackRootName: string) => {
         dialog.open(
             () => (
                 <StackPreparingModal
-                    kind={kind}
+                    kind="sync"
                     stackRootName={stackRootName}
                 />
             ),
             {
-                id: `bookmark-stack-${kind}-preparing`,
+                id: "bookmark-stack-sync-preparing",
                 title: [
-                    {
-                        text:
-                            kind === "submit"
-                                ? "Submit preview"
-                                : "Sync preview",
-                        style: "action",
-                    },
-                    " for ",
+                    { text: "sync", style: "action" },
+                    " preview for ",
                     { text: stackRootName, style: "target" },
                 ],
                 ...DIALOG_SIZE.confirmWide,
+                minHeight: 18,
                 closeOnEsc: false,
                 hints: [],
             },
         )
         try {
-            const plan = await preparePlan(kind, stackRootName)
+            const plan = await preparePlan(stackRootName)
             dialog.close()
             dialog.open(
                 () => (
@@ -409,19 +392,14 @@ export function BookmarksPanel() {
                     />
                 ),
                 {
-                    id: `bookmark-stack-${kind}-plan`,
+                    id: "bookmark-stack-sync-plan",
                     title: [
-                        {
-                            text:
-                                kind === "submit"
-                                    ? "Submit preview"
-                                    : "Sync preview",
-                            style: "action",
-                        },
-                        " for ",
+                        { text: "sync", style: "action" },
+                        " preview for ",
                         { text: stackRootName, style: "target" },
                     ],
                     ...DIALOG_SIZE.confirmWide,
+                    minHeight: 18,
                     closeOnEsc: false,
                     hints:
                         plan.effects.length > 0
@@ -443,13 +421,10 @@ export function BookmarksPanel() {
         }
     }
 
-    const prepareAndApplyStack = async (
-        kind: "submit" | "sync",
-        stackRootName: string,
-    ) => {
+    const prepareAndApplyStack = async (stackRootName: string) => {
         const observer = commandLog.observer()
         try {
-            const plan = await preparePlan(kind, stackRootName, observer)
+            const plan = await preparePlan(stackRootName, observer)
             if (plan.effects.length === 0) {
                 status.show("Nothing to do; stack is already in sync.")
                 return
@@ -457,7 +432,7 @@ export function BookmarksPanel() {
             await applyPreparedPlan(plan)
         } catch (error) {
             commandLog.addEntry({
-                command: kind === "submit" ? "stack submit" : "stack sync",
+                command: "stack sync",
                 success: false,
                 exitCode: 1,
                 stdout: "",
@@ -470,26 +445,8 @@ export function BookmarksPanel() {
         {
             key: "s",
             mutedPrefix: "stack ",
-            label: "submit --dry-run",
-            onSelect: () => openStackPlan("submit", stackRootName),
-        },
-        {
-            key: "S",
-            mutedPrefix: "stack ",
-            label: "submit",
-            onSelect: () => prepareAndApplyStack("submit", stackRootName),
-        },
-        {
-            key: "f",
-            mutedPrefix: "stack ",
-            label: "sync --dry-run",
-            onSelect: () => openStackPlan("sync", stackRootName),
-        },
-        {
-            key: "F",
-            mutedPrefix: "stack ",
             label: "sync",
-            onSelect: () => prepareAndApplyStack("sync", stackRootName),
+            onSelect: () => openStackPlan(stackRootName),
         },
     ]
 
@@ -522,6 +479,7 @@ export function BookmarksPanel() {
                     { text: stackRootName, style: "target" },
                 ],
                 ...DIALOG_SIZE.confirmWide,
+                minHeight: 18,
                 hints: [
                     { key: "enter", label: "run" },
                     { key: "esc", label: "close" },
@@ -556,11 +514,19 @@ export function BookmarksPanel() {
         )
     }
 
-    const openSelectedStack = () => {
+    const openSelectedStack = async () => {
         if (showRemoteOnly()) return
         const row = selectedBookmarkRow()
         if (!row) return
         if (row.stackKeys.length === 0) {
+            const persisted = await readPersistedStackState()
+            const entry = persisted.entries.find(
+                (item) => item.bookmark === row.bookmark.name,
+            )
+            if (entry?.parent) {
+                openStackPlan(entry.parent)
+                return
+            }
             status.show(`No stack for ${row.bookmark.name}.`)
             return
         }

--- a/src/components/panels/BookmarksPanel.tsx
+++ b/src/components/panels/BookmarksPanel.tsx
@@ -45,8 +45,12 @@ import { useStatus } from "../../context/status"
 import { useSync } from "../../context/sync"
 import { useTheme } from "../../context/theme"
 import { buildBookmarkStackModel } from "../../stack/discovery"
+import {
+    applyStackPlan,
+    prepareSubmitPlan,
+    prepareSyncPlan,
+} from "../../stack/executor"
 import type { BookmarkStackModel, BookmarkStackRow } from "../../stack/model"
-import { buildSubmitPlanSync, buildSyncPlanSync } from "../../stack/planner"
 import { hasOriginDiff } from "../../utils/bookmark-origin-diff"
 import { createDoubleClickDetector } from "../../utils/double-click"
 import { FUZZY_THRESHOLD, scrollIntoView } from "../../utils/scroll"
@@ -366,65 +370,98 @@ export function BookmarksPanel() {
         return row.stackKeys[0]
     })
 
-    const remoteBookmarksByName = () =>
-        new Map(
-            remoteBookmarks()
-                .filter((bookmark) => !bookmark.isLocal)
-                .map((bookmark) => [bookmark.name, bookmark]),
+    const applyPreparedPlan = async (
+        plan: Parameters<typeof applyStackPlan>[0],
+    ) => {
+        const observer = commandLog.observer()
+        try {
+            await Effect.runPromise(applyStackPlan(plan, { observer }))
+            refresh()
+            setPrMetadataRefreshToken((token) => token + 1)
+        } catch (error) {
+            commandLog.addEntry({
+                command: plan.applyCommand,
+                success: false,
+                exitCode: 1,
+                stdout: "",
+                stderr: error instanceof Error ? error.message : String(error),
+            })
+        }
+    }
+
+    const preparePlan = async (
+        kind: "submit" | "sync",
+        stackRootName: string,
+        observer?: ReturnType<typeof commandLog.observer>,
+    ) =>
+        Effect.runPromise(
+            kind === "submit"
+                ? prepareSubmitPlan({ stackRootName, observer })
+                : prepareSyncPlan({ stackRootName, observer }),
         )
 
-    const openStackPlan = (kind: "submit" | "sync", stackRootName: string) => {
-        const stackModel = displayBookmarkStackModel()
-        if (!stackModel) return
-        const plan =
-            kind === "submit"
-                ? buildSubmitPlanSync({
-                      stackRootName,
-                      stackModel,
-                      pullRequestsByHead: pullRequestsByHead(),
-                      remoteBookmarksByName: remoteBookmarksByName(),
-                  })
-                : buildSyncPlanSync({
-                      stackRootName,
-                      stackModel,
-                      pullRequestsByHead: pullRequestsByHead(),
-                      remoteBookmarksByName: remoteBookmarksByName(),
-                  })
-        dialog.open(
-            () => (
-                <StackPlanModal
-                    plan={plan}
-                    onApply={() =>
-                        status.show(
-                            kind === "submit"
-                                ? `Stack submit for ${stackRootName} is not implemented yet.`
-                                : `Stack sync for ${stackRootName} is not implemented yet.`,
-                        )
-                    }
-                    onBack={() => openStackActions(stackRootName)}
-                />
-            ),
-            {
-                id: `bookmark-stack-${kind}-plan`,
-                title: [
-                    {
-                        text:
-                            kind === "submit"
-                                ? "Submit preview"
-                                : "Sync preview",
-                        style: "action",
-                    },
-                    " for ",
-                    { text: stackRootName, style: "target" },
-                ],
-                ...DIALOG_SIZE.confirmWide,
-                closeOnEsc: false,
-                hints: [
-                    { key: "enter", label: "apply" },
-                    { key: "esc", label: "back" },
-                ],
-            },
-        )
+    const openStackPlan = async (
+        kind: "submit" | "sync",
+        stackRootName: string,
+    ) => {
+        try {
+            const plan = await preparePlan(kind, stackRootName)
+            dialog.open(
+                () => (
+                    <StackPlanModal
+                        plan={plan}
+                        onApply={() => applyPreparedPlan(plan)}
+                        onBack={() => openStackActions(stackRootName)}
+                    />
+                ),
+                {
+                    id: `bookmark-stack-${kind}-plan`,
+                    title: [
+                        {
+                            text:
+                                kind === "submit"
+                                    ? "Submit preview"
+                                    : "Sync preview",
+                            style: "action",
+                        },
+                        " for ",
+                        { text: stackRootName, style: "target" },
+                    ],
+                    ...DIALOG_SIZE.confirmWide,
+                    closeOnEsc: false,
+                    hints: [
+                        { key: "enter", label: "apply" },
+                        { key: "esc", label: "back" },
+                    ],
+                },
+            )
+        } catch (error) {
+            status.show(
+                error instanceof Error ? error.message : String(error),
+                {
+                    kind: "error",
+                },
+            )
+        }
+    }
+
+    const prepareAndApplyStack = async (
+        kind: "submit" | "sync",
+        stackRootName: string,
+    ) => {
+        const observer = commandLog.observer()
+        try {
+            const plan = await preparePlan(kind, stackRootName, observer)
+            await applyPreparedPlan(plan)
+        } catch (error) {
+            commandLog.addEntry({
+                command: kind === "submit" ? "stack submit" : "stack sync",
+                success: false,
+                exitCode: 1,
+                stdout: "",
+                stderr: error instanceof Error ? error.message : String(error),
+            })
+        }
     }
 
     const stackActionOptions = (stackRootName: string) => [
@@ -438,10 +475,7 @@ export function BookmarksPanel() {
             key: "S",
             mutedPrefix: "stack ",
             label: "submit",
-            onSelect: () =>
-                status.show(
-                    `Stack submit for ${stackRootName} is not implemented yet.`,
-                ),
+            onSelect: () => prepareAndApplyStack("submit", stackRootName),
         },
         {
             key: "f",
@@ -453,10 +487,7 @@ export function BookmarksPanel() {
             key: "F",
             mutedPrefix: "stack ",
             label: "sync",
-            onSelect: () =>
-                status.show(
-                    `Stack sync for ${stackRootName} is not implemented yet.`,
-                ),
+            onSelect: () => prepareAndApplyStack("sync", stackRootName),
         },
     ]
 

--- a/src/components/panels/LogPanel.tsx
+++ b/src/components/panels/LogPanel.tsx
@@ -23,7 +23,11 @@ import {
     jjBookmarkSet,
 } from "../../commander/bookmarks"
 import { withCommandObserver } from "../../commander/executor"
-import { ghBrowseCommit, ghPrCreateWeb } from "../../commander/github"
+import {
+    ghBrowseCommit,
+    ghPrCreateWeb,
+    ghPrViewWeb,
+} from "../../commander/github"
 import { fetchLogPage } from "../../commander/log"
 import {
     type OpLogEntry,
@@ -246,6 +250,8 @@ export function LogPanel() {
         logLoadingMore,
         activeBookmarkDiff,
         enterBookmarkDiffView,
+        bookmarkPrNumbers,
+        refreshPullRequestMetadata,
     } = useSync()
     const focus = useFocus()
     const command = useCommand()
@@ -786,9 +792,15 @@ export function LogPanel() {
             await refresh()
         }
 
+        const existingPrNumber = bookmarkPrNumbers().get(bookmark.name)
         const observer = commandLog.observer()
-        const prResult = await ghPrCreateWeb(bookmark.name, { observer })
+        const prResult = existingPrNumber
+            ? await ghPrViewWeb(existingPrNumber, { observer })
+            : await ghPrCreateWeb(bookmark.name, { observer })
         commandLog.addEntry(prResult)
+        if (prResult.success) {
+            refreshPullRequestMetadata()
+        }
     }
 
     const openForCommit = async (options?: { direct?: boolean }) => {

--- a/src/context/dialog.tsx
+++ b/src/context/dialog.tsx
@@ -51,6 +51,7 @@ interface DialogState {
     title?: string | StyledSegment[]
     width?: DimensionOrAccessor
     maxWidth?: number
+    closeOnEsc?: boolean
 }
 
 export type StyledSegment =
@@ -179,7 +180,12 @@ export const { use: useDialog, provider: DialogProvider } = createSimpleContext(
             }
 
             useKeyboard((evt) => {
-                if (stack().length > 0 && evt.name === "escape") {
+                const current = stack().at(-1)
+                if (
+                    current &&
+                    current.closeOnEsc !== false &&
+                    evt.name === "escape"
+                ) {
                     evt.preventDefault()
                     evt.stopPropagation()
                     close()
@@ -195,6 +201,7 @@ export const { use: useDialog, provider: DialogProvider } = createSimpleContext(
                     title?: string | StyledSegment[]
                     width?: DimensionOrAccessor
                     maxWidth?: number
+                    closeOnEsc?: boolean
                 },
             ) => {
                 setStack((s) => [
@@ -207,6 +214,7 @@ export const { use: useDialog, provider: DialogProvider } = createSimpleContext(
                         title: options?.title,
                         width: options?.width,
                         maxWidth: options?.maxWidth,
+                        closeOnEsc: options?.closeOnEsc,
                     },
                 ])
             }
@@ -220,6 +228,7 @@ export const { use: useDialog, provider: DialogProvider } = createSimpleContext(
                     title?: string | StyledSegment[]
                     width?: DimensionOrAccessor
                     maxWidth?: number
+                    closeOnEsc?: boolean
                 },
             ) => {
                 const current = stack().at(-1)
@@ -233,6 +242,7 @@ export const { use: useDialog, provider: DialogProvider } = createSimpleContext(
                         title: options?.title,
                         width: options?.width,
                         maxWidth: options?.maxWidth,
+                        closeOnEsc: options?.closeOnEsc,
                     })
                 }
             }

--- a/src/context/dialog.tsx
+++ b/src/context/dialog.tsx
@@ -24,6 +24,7 @@ type Dimension = number | "auto" | `${number}%`
 export interface DialogSize {
     width?: Dimension
     maxWidth?: number
+    minHeight?: number
 }
 
 export const DIALOG_SIZE = {
@@ -51,6 +52,7 @@ interface DialogState {
     title?: string | StyledSegment[]
     width?: DimensionOrAccessor
     maxWidth?: number
+    minHeight?: number
     closeOnEsc?: boolean
 }
 
@@ -201,6 +203,7 @@ export const { use: useDialog, provider: DialogProvider } = createSimpleContext(
                     title?: string | StyledSegment[]
                     width?: DimensionOrAccessor
                     maxWidth?: number
+                    minHeight?: number
                     closeOnEsc?: boolean
                 },
             ) => {
@@ -214,6 +217,7 @@ export const { use: useDialog, provider: DialogProvider } = createSimpleContext(
                         title: options?.title,
                         width: options?.width,
                         maxWidth: options?.maxWidth,
+                        minHeight: options?.minHeight,
                         closeOnEsc: options?.closeOnEsc,
                     },
                 ])
@@ -228,6 +232,7 @@ export const { use: useDialog, provider: DialogProvider } = createSimpleContext(
                     title?: string | StyledSegment[]
                     width?: DimensionOrAccessor
                     maxWidth?: number
+                    minHeight?: number
                     closeOnEsc?: boolean
                 },
             ) => {
@@ -242,6 +247,7 @@ export const { use: useDialog, provider: DialogProvider } = createSimpleContext(
                         title: options?.title,
                         width: options?.width,
                         maxWidth: options?.maxWidth,
+                        minHeight: options?.minHeight,
                         closeOnEsc: options?.closeOnEsc,
                     })
                 }
@@ -295,6 +301,7 @@ export const { use: useDialog, provider: DialogProvider } = createSimpleContext(
                 resolvedWidth: () =>
                     resolveWidth(stack().at(-1)?.width) ?? "50%",
                 maxWidth: () => stack().at(-1)?.maxWidth,
+                minHeight: () => stack().at(-1)?.minHeight,
                 setHints: (hints: DialogHint[]) => {
                     setStack((s) => {
                         if (s.length === 0) return s
@@ -408,6 +415,7 @@ function DialogBackdrop(props: { children: JSX.Element }) {
                 flexDirection="column"
                 width={dialog.resolvedWidth()}
                 maxWidth={dialog.maxWidth()}
+                minHeight={dialog.minHeight()}
                 backgroundColor={colors().background}
                 paddingLeft={2}
                 paddingRight={2}

--- a/src/context/dialog.tsx
+++ b/src/context/dialog.tsx
@@ -428,7 +428,9 @@ function DialogBackdrop(props: { children: JSX.Element }) {
                         <StyledText content={title()} bold />
                     )}
                 </Show>
-                {props.children}
+                <box flexDirection="column" flexGrow={1}>
+                    {props.children}
+                </box>
                 <DialogHints hints={dialog.hints()} />
             </box>
         </box>

--- a/src/context/sync.tsx
+++ b/src/context/sync.tsx
@@ -15,6 +15,10 @@ import {
     fetchBookmarks,
     fetchBookmarksStream,
 } from "../commander/bookmarks"
+import {
+    type GitHubPullRequestSummary,
+    ghListPullRequestsByHead,
+} from "../commander/github"
 import { getRepoPath } from "../repo"
 import { addRecentRepo } from "../utils/state"
 import { getVisibleBookmarks } from "./sync-bookmarks"
@@ -134,6 +138,9 @@ interface SyncContextValue {
     selectFirstBookmark: () => void
     selectLastBookmark: () => void
     jumpToBookmarkCommit: () => number | null
+    pullRequestsByHead: () => ReadonlyMap<string, GitHubPullRequestSummary>
+    bookmarkPrNumbers: () => ReadonlyMap<string, number>
+    refreshPullRequestMetadata: () => void
 
     refresh: (options?: RefreshOptions) => Promise<void>
     refreshCounter: () => number
@@ -190,6 +197,27 @@ export function SyncProvider(props: { children: JSX.Element }) {
     const visibleBookmarks = createMemo(() =>
         getVisibleBookmarks(bookmarks(), bookmarkLimit()),
     )
+    const [pullRequestsByHead, setPullRequestsByHead] = createSignal<
+        ReadonlyMap<string, GitHubPullRequestSummary>
+    >(new Map())
+    const bookmarkPrNumbers = createMemo(
+        () =>
+            new Map(
+                [...pullRequestsByHead()].map(([head, pull]) => [
+                    head,
+                    pull.number,
+                ]),
+            ),
+    )
+    const [prMetadataRefreshToken, setPrMetadataRefreshToken] = createSignal(0)
+    const refreshPullRequestMetadata = () => {
+        setPrMetadataRefreshToken((token) => token + 1)
+    }
+    const refreshPullRequestMetadataSoon = () => {
+        setTimeout(refreshPullRequestMetadata, 15000)
+        setTimeout(refreshPullRequestMetadata, 30000)
+        setTimeout(refreshPullRequestMetadata, 60000)
+    }
 
     const [commitDetails, setCommitDetails] =
         createSignal<CommitDetails | null>(null)
@@ -536,6 +564,32 @@ export function SyncProvider(props: { children: JSX.Element }) {
 
     const localBookmarks = () => bookmarks().filter((b) => b.isLocal)
     const selectedBookmark = () => localBookmarks()[selectedBookmarkIndex()]
+
+    createEffect(() => {
+        prMetadataRefreshToken()
+        const names = localBookmarks()
+            .filter((bookmark) => bookmark.changeId)
+            .map((bookmark) => bookmark.name)
+            .sort()
+        if (names.length === 0) {
+            setPullRequestsByHead(new Map())
+            return
+        }
+
+        let cancelled = false
+        ghListPullRequestsByHead(names)
+            .then((pullsByHead) => {
+                if (cancelled) return
+                setPullRequestsByHead(pullsByHead)
+            })
+            .catch(() => {
+                if (!cancelled) setPullRequestsByHead(new Map())
+            })
+
+        onCleanup(() => {
+            cancelled = true
+        })
+    })
 
     createEffect(() => {
         const maxIndex = localBookmarks().length - 1
@@ -1048,6 +1102,9 @@ export function SyncProvider(props: { children: JSX.Element }) {
         selectFirstBookmark,
         selectLastBookmark,
         jumpToBookmarkCommit,
+        pullRequestsByHead,
+        bookmarkPrNumbers,
+        refreshPullRequestMetadata: refreshPullRequestMetadataSoon,
 
         refresh: doFullRefresh,
         refreshCounter,

--- a/src/feature-flags.ts
+++ b/src/feature-flags.ts
@@ -1,0 +1,10 @@
+const truthy = new Set(["1", "true", "yes", "on"])
+
+function envFlag(name: string): boolean {
+    const value = process.env[name]
+    return typeof value === "string" && truthy.has(value.toLowerCase())
+}
+
+export const featureFlags = {
+    githubStacking: () => envFlag("KAJJI_ENABLE_STACKING"),
+}

--- a/src/keybind/types.ts
+++ b/src/keybind/types.ts
@@ -47,6 +47,7 @@ export type KeybindConfigKey =
     | "bookmark_forget"
     | "bookmark_set"
     | "bookmark_move"
+    | "bookmark_stack"
     | "bookmark_diff_origin"
     | "bookmark_toggle_remote"
     | "toggle_file_tree"
@@ -111,6 +112,7 @@ export const DEFAULT_KEYBINDS: KeybindConfig = {
     bookmark_forget: "x",
     bookmark_set: "b",
     bookmark_move: "m",
+    bookmark_stack: "s",
     bookmark_diff_origin: "C",
     bookmark_toggle_remote: "R",
     toggle_file_tree: "-",

--- a/src/stack/discovery.ts
+++ b/src/stack/discovery.ts
@@ -1,0 +1,176 @@
+import { Effect } from "effect"
+import type {
+    BookmarkStackModel,
+    BookmarkStackRow,
+    StackBookmarkInput,
+    StackCommitInput,
+} from "./model"
+
+export interface BuildBookmarkStackModelOptions<
+    TBookmark extends StackBookmarkInput,
+> {
+    readonly commits: readonly StackCommitInput[]
+    readonly bookmarks: readonly TBookmark[]
+    /** Preserve current panel order when sorting children and flat rows. */
+    readonly sourceOrder?: ReadonlyMap<string, number>
+}
+
+export const buildBookmarkStackModel = Effect.fn("Stack.buildBookmarkModel")(
+    function* <TBookmark extends StackBookmarkInput>({
+        commits,
+        bookmarks,
+        sourceOrder,
+    }: BuildBookmarkStackModelOptions<TBookmark>) {
+        const commitsByCommitId = new Map(
+            commits.map((commit) => [commit.commitId, commit]),
+        )
+        const order =
+            sourceOrder ??
+            new Map(bookmarks.map((bookmark, index) => [bookmark.name, index]))
+        const candidates = bookmarks.filter(
+            (bookmark) => bookmark.changeId && bookmark.commitId,
+        )
+        const candidateNames = new Set(
+            candidates.map((bookmark) => bookmark.name),
+        )
+        const bookmarkCommitIds = new Map(
+            candidates.map((bookmark) => [bookmark.name, bookmark.commitId]),
+        )
+        const trunkNames = new Set(
+            candidates
+                .filter(
+                    (bookmark) =>
+                        commitsByCommitId.get(bookmark.commitId)?.immutable,
+                )
+                .map((bookmark) => bookmark.name),
+        )
+        const defaultTrunk =
+            candidates.find((bookmark) => trunkNames.has(bookmark.name)) ?? null
+
+        const parentByName = new Map<string, string>()
+        for (const bookmark of candidates) {
+            if (trunkNames.has(bookmark.name)) continue
+            const bookmarkCommitId = bookmarkCommitIds.get(bookmark.name)
+            if (!bookmarkCommitId) continue
+
+            let parent: TBookmark | undefined
+            let parentDistance = Number.POSITIVE_INFINITY
+            for (const possibleParent of candidates) {
+                if (possibleParent.name === bookmark.name) continue
+                if (trunkNames.has(possibleParent.name)) continue
+                const possibleParentCommitId = bookmarkCommitIds.get(
+                    possibleParent.name,
+                )
+                if (!possibleParentCommitId) continue
+                const distance = ancestorDistance(
+                    possibleParentCommitId,
+                    bookmarkCommitId,
+                    commitsByCommitId,
+                )
+                if (distance < parentDistance) {
+                    parent = possibleParent
+                    parentDistance = distance
+                }
+            }
+
+            if (parent) parentByName.set(bookmark.name, parent.name)
+        }
+
+        const stackRootNames = new Set(parentByName.values())
+        if (defaultTrunk) {
+            for (const bookmark of candidates) {
+                if (trunkNames.has(bookmark.name)) continue
+                if (parentByName.has(bookmark.name)) continue
+                if (!stackRootNames.has(bookmark.name)) continue
+                parentByName.set(bookmark.name, defaultTrunk.name)
+            }
+        }
+
+        const childrenByName = new Map<string, TBookmark[]>()
+        for (const bookmark of bookmarks) {
+            const parent = parentByName.get(bookmark.name)
+            if (!parent || !candidateNames.has(parent)) continue
+            const children = childrenByName.get(parent) ?? []
+            children.push(bookmark)
+            childrenByName.set(parent, children)
+        }
+        for (const children of childrenByName.values()) {
+            children.sort(
+                (a, b) => (order.get(a.name) ?? 0) - (order.get(b.name) ?? 0),
+            )
+        }
+
+        const rows: BookmarkStackRow<TBookmark>[] = []
+        const seen = new Set<string>()
+        const visit = (
+            bookmark: TBookmark,
+            depth: number,
+            stackKey?: string,
+        ) => {
+            if (seen.has(bookmark.name)) return
+            seen.add(bookmark.name)
+
+            const isTrunk = trunkNames.has(bookmark.name)
+            const currentStackKey =
+                stackKey ??
+                (!isTrunk && childrenByName.has(bookmark.name)
+                    ? bookmark.name
+                    : undefined)
+            const targetStackKeys = isTrunk
+                ? (childrenByName.get(bookmark.name) ?? []).map(
+                      (child) => child.name,
+                  )
+                : []
+            const stackKeys = isTrunk
+                ? targetStackKeys
+                : currentStackKey
+                  ? [currentStackKey]
+                  : []
+            rows.push({ bookmark, depth, stackKeys })
+
+            for (const child of childrenByName.get(bookmark.name) ?? []) {
+                visit(child, depth + 1, currentStackKey)
+            }
+        }
+
+        for (const bookmark of bookmarks) {
+            if (parentByName.has(bookmark.name)) continue
+            visit(bookmark, 0)
+        }
+        for (const bookmark of bookmarks) visit(bookmark, 0)
+
+        return {
+            rows,
+            parentByName,
+            childrenByName,
+            trunkNames,
+            stackRootNames,
+        } satisfies BookmarkStackModel<TBookmark>
+    },
+)
+
+const ancestorDistance = (
+    ancestorCommitId: string,
+    descendantCommitId: string,
+    commitsByCommitId: ReadonlyMap<string, StackCommitInput>,
+) => {
+    const pending: Array<{ commitId: string; distance: number }> = [
+        { commitId: descendantCommitId, distance: 0 },
+    ]
+    const seen = new Set<string>()
+    while (pending.length > 0) {
+        const item = pending.shift()
+        if (!item || seen.has(item.commitId)) continue
+        seen.add(item.commitId)
+        const commit = commitsByCommitId.get(item.commitId)
+        if (!commit) continue
+        for (const parentCommitId of commit.parentCommitIds ?? []) {
+            if (parentCommitId === ancestorCommitId) return item.distance + 1
+            pending.push({
+                commitId: parentCommitId,
+                distance: item.distance + 1,
+            })
+        }
+    }
+    return Number.POSITIVE_INFINITY
+}

--- a/src/stack/errors.ts
+++ b/src/stack/errors.ts
@@ -1,0 +1,8 @@
+import { Schema } from "effect"
+
+export class StackDiscoveryError extends Schema.TaggedErrorClass<StackDiscoveryError>()(
+    "StackDiscoveryError",
+    {
+        message: Schema.String,
+    },
+) {}

--- a/src/stack/executor.ts
+++ b/src/stack/executor.ts
@@ -5,7 +5,6 @@ import {
     ghPrClose,
     ghPrCreate,
     ghPrEditBase,
-    ghPrViewWeb,
     ghUpsertStackComment,
 } from "../commander/github"
 import { fetchLogPage } from "../commander/log"
@@ -281,8 +280,6 @@ async function applySyncPlan(
         }
     }
 
-    let firstCreatedPrNumber: number | undefined
-
     for (const row of plan.rows) {
         const bookmark = row.row.bookmark
         const createEffect = row.effects.find(
@@ -301,7 +298,6 @@ async function applySyncPlan(
         const pull = fresh.get(bookmark.name)
         if (pull) {
             prByBookmark.set(bookmark.name, pull.number)
-            firstCreatedPrNumber ??= pull.number
             journal.entries.push({
                 type: "PrCreated",
                 prNumber: pull.number,
@@ -373,8 +369,6 @@ async function applySyncPlan(
         journal.entries.push({ type: "StackCommentUpdated", prNumber })
     }
 
-    const prToOpen = firstCreatedPrNumber ?? stackPrNumbers[0]
-    if (prToOpen) await ghPrViewWeb(prToOpen, options)
     return prByBookmark
 }
 

--- a/src/stack/executor.ts
+++ b/src/stack/executor.ts
@@ -1,7 +1,6 @@
 import { Effect } from "effect"
 import { type Bookmark, fetchBookmarks } from "../commander/bookmarks"
 import {
-    type GitHubPullRequestSummary,
     ghListPullRequestsByHead,
     ghPrClose,
     ghPrCreate,
@@ -17,16 +16,21 @@ import {
     jjGitFetch,
     jjGitPushBookmark,
     jjRebase,
+    jjRevsetHasMatches,
 } from "../commander/operations"
 import { getRepoPath } from "../repo"
 import { buildBookmarkStackModel } from "./discovery"
 import type {
     BookmarkStackModel,
     StackPlan,
-    StackPlanEffect,
     StackPullRequestInput,
 } from "./model"
-import { buildSubmitPlanSync, buildSyncPlanSync } from "./planner"
+import { buildSyncPlanSync } from "./planner"
+import {
+    type PersistedStackEntry,
+    readPersistedStackState,
+    writePersistedStackState,
+} from "./state"
 
 export interface PrepareStackPlanOptions {
     readonly stackRootName: string
@@ -39,23 +43,6 @@ export interface ApplyStackPlanOptions {
 
 type FreshBookmark = Bookmark
 
-export const prepareSubmitPlan = Effect.fn("Stack.prepareSubmitPlan")(
-    (options: PrepareStackPlanOptions) =>
-        Effect.promise(async () => {
-            const state = await loadFreshState({
-                stackRootName: options.stackRootName,
-                observer: options.observer,
-                includeClosedPulls: false,
-            })
-            return buildSubmitPlanSync({
-                stackRootName: options.stackRootName,
-                stackModel: state.stackModel,
-                pullRequestsByHead: state.pullRequestsByHead,
-                remoteBookmarksByName: state.remoteBookmarksByName,
-            })
-        }),
-)
-
 export const prepareSyncPlan = Effect.fn("Stack.prepareSyncPlan")(
     (options: PrepareStackPlanOptions) =>
         Effect.promise(async () => {
@@ -64,11 +51,16 @@ export const prepareSyncPlan = Effect.fn("Stack.prepareSyncPlan")(
                 observer: options.observer,
                 includeClosedPulls: true,
             })
+            const landedRangesByBookmark = await detectLandedParentRanges(
+                state.stackModel,
+                state.pullRequestsByHead,
+            )
             return buildSyncPlanSync({
                 stackRootName: options.stackRootName,
                 stackModel: state.stackModel,
                 pullRequestsByHead: state.pullRequestsByHead,
                 remoteBookmarksByName: state.remoteBookmarksByName,
+                landedRangesByBookmark,
             })
         }),
 )
@@ -79,11 +71,8 @@ export const applyStackPlan = Effect.fn("Stack.applyPlan")(
             if (plan.effects.length === 0) return
             const beforeOp = await fetchOpLogId()
             const journal = stackJournal(plan, beforeOp)
-            if (plan.kind === "submit") {
-                await applySubmitPlan(plan, journal, options)
-            } else {
-                await applySyncPlan(plan, journal, options)
-            }
+            const prByBookmark = await applySyncPlan(plan, journal, options)
+            await persistStackStateFromPlan(plan, prByBookmark)
             journal.afterOperationId = await fetchOpLogId()
             await writeJournal(journal)
         }),
@@ -102,10 +91,14 @@ async function loadFreshState(options: {
         throw new Error(fetchResult.stderr || fetchResult.stdout)
 
     const freshState = await readStackState()
-    const localBookmarks = reconcileFetchedLocalBookmarks(
-        freshState.localBookmarks,
-        preFetchState?.stackModel,
-        options.stackRootName,
+    const persistedState = await readPersistedStackState()
+    const localBookmarks = restorePersistedLocalBookmarks(
+        reconcileFetchedLocalBookmarks(
+            freshState.localBookmarks,
+            preFetchState?.stackModel,
+            options.stackRootName,
+        ),
+        persistedState.entries,
     )
     const remoteBookmarks = freshState.remoteBookmarks
     const stackModel = Effect.runSync(
@@ -114,7 +107,10 @@ async function loadFreshState(options: {
             bookmarks: localBookmarks,
         }),
     )
-    const heads = stackModel.rows.map((row) => row.bookmark.name)
+    const heads = uniqueStrings([
+        ...stackModel.rows.map((row) => row.bookmark.name),
+        ...persistedState.entries.map((entry) => entry.bookmark),
+    ])
     const pullRequestsByHead = new Map<string, StackPullRequestInput>(
         [
             ...(await ghListPullRequestsByHead(heads, {
@@ -154,6 +150,36 @@ async function readStackState() {
     }
 }
 
+function restorePersistedLocalBookmarks(
+    localBookmarks: readonly FreshBookmark[],
+    entries: readonly PersistedStackEntry[],
+): readonly FreshBookmark[] {
+    const localNames = new Set(localBookmarks.map((bookmark) => bookmark.name))
+    const restored = entries.flatMap((entry) => {
+        if (localNames.has(entry.bookmark)) return []
+        const headCommitId = entry.headCommitId
+        const headChangeId = entry.headChangeId
+        if (!headCommitId || !headChangeId) return []
+        return [
+            {
+                name: entry.bookmark,
+                nameDisplay: entry.bookmark,
+                commitId: headCommitId,
+                commitIdDisplay: headCommitId.slice(0, 8),
+                changeId: headChangeId,
+                changeIdDisplay: headChangeId,
+                description: "",
+                descriptionDisplay: "",
+                isLocal: true,
+                remote: undefined,
+            } satisfies FreshBookmark,
+        ]
+    })
+    return restored.length > 0
+        ? [...localBookmarks, ...restored]
+        : localBookmarks
+}
+
 function reconcileFetchedLocalBookmarks(
     localBookmarks: readonly FreshBookmark[],
     preFetchStackModel: BookmarkStackModel<FreshBookmark> | undefined,
@@ -175,7 +201,41 @@ function reconcileFetchedLocalBookmarks(
     return [...localBookmarks, ...restoredBookmarks]
 }
 
-async function applySubmitPlan(
+async function detectLandedParentRanges(
+    stackModel: BookmarkStackModel<FreshBookmark>,
+    pullRequestsByHead: ReadonlyMap<string, StackPullRequestInput>,
+): Promise<ReadonlyMap<string, string>> {
+    const persisted = await readPersistedStackState()
+    const persistedByBookmark = new Map(
+        persisted.entries.map((entry) => [entry.bookmark, entry]),
+    )
+    const ranges = new Map<string, string>()
+
+    for (const row of stackModel.rows) {
+        const bookmark = row.bookmark
+        const entry = persistedByBookmark.get(bookmark.name)
+        if (!entry) continue
+        const previousParent = persistedByBookmark.get(entry.parent)
+        if (!previousParent) continue
+        const parentPull = pullRequestsByHead.get(previousParent.bookmark)
+        if (parentPull?.merged !== true && parentPull?.state !== "MERGED") {
+            continue
+        }
+        const currentBase =
+            parentPull.baseRefName ?? stackModel.parentByName.get(bookmark.name)
+        const oldBase = previousParent.parentChangeId ?? previousParent.parent
+        const oldHead = previousParent.headChangeId ?? previousParent.bookmark
+        if (!currentBase) continue
+        const range = `(${oldBase}..${oldHead}) & ancestors(${bookmark.changeId ?? bookmark.name}) ~ ancestors(${currentBase})`
+        if (await jjRevsetHasMatches(range)) {
+            ranges.set(bookmark.name, range)
+        }
+    }
+
+    return ranges
+}
+
+async function applySyncPlan(
     plan: StackPlan<FreshBookmark>,
     journal: StackJournalFile,
     options: ApplyStackPlanOptions,
@@ -187,9 +247,33 @@ async function applySubmitPlan(
     )
 
     for (const effect of plan.effects) {
-        if (effect.type === "push") {
+        if (effect.type !== "abandon" && effect.type !== "abandon-landed-range")
+            continue
+        const result = await jjAbandon(
+            effect.range ?? effect.revision ?? effect.bookmark,
+            {
+                observer: options.observer,
+            },
+        )
+        if (!result.success) throw new Error(result.stderr || result.stdout)
+        journal.entries.push({
+            type:
+                effect.type === "abandon-landed-range"
+                    ? "LandedRangeAbandoned"
+                    : "BookmarkAbandoned",
+            bookmark: effect.bookmark,
+            prNumber: effect.prNumber,
+        })
+    }
+
+    const pushedBookmarks = new Set<string>()
+    for (const row of plan.rows) {
+        if (!row.effects.some((effect) => effect.type === "create-pr")) continue
+        for (const effect of row.effects) {
+            if (effect.type !== "push") continue
             const result = await jjGitPushBookmark(effect.bookmark, options)
             if (!result.success) throw new Error(result.stderr || result.stdout)
+            pushedBookmarks.add(effect.bookmark)
             journal.entries.push({
                 type: "BookmarkPushed",
                 bookmark: effect.bookmark,
@@ -227,56 +311,6 @@ async function applySubmitPlan(
     }
 
     for (const effect of plan.effects) {
-        if (effect.type !== "update-pr" || !effect.prNumber || !effect.to)
-            continue
-        const result = await ghPrEditBase(effect.prNumber, effect.to, options)
-        if (!result.success) throw new Error(result.stderr || result.stdout)
-        journal.entries.push({
-            type: "PrBaseChanged",
-            prNumber: effect.prNumber,
-            from: effect.from,
-            to: effect.to,
-        })
-    }
-
-    const stackPrNumbers = plan.rows
-        .map((row) => prByBookmark.get(row.row.bookmark.name) ?? row.prNumber)
-        .filter((number): number is number => typeof number === "number")
-    for (const row of plan.rows) {
-        const prNumber = prByBookmark.get(row.row.bookmark.name) ?? row.prNumber
-        if (!prNumber) continue
-        const result = await ghUpsertStackComment(
-            prNumber,
-            renderStackComment(prNumber, stackPrNumbers),
-            options,
-        )
-        if (!result.success) throw new Error(result.stderr || result.stdout)
-        journal.entries.push({ type: "StackCommentUpdated", prNumber })
-    }
-
-    const prToOpen = firstCreatedPrNumber ?? stackPrNumbers[0]
-    if (prToOpen) await ghPrViewWeb(prToOpen, options)
-}
-
-async function applySyncPlan(
-    plan: StackPlan<FreshBookmark>,
-    journal: StackJournalFile,
-    options: ApplyStackPlanOptions,
-) {
-    for (const effect of plan.effects) {
-        if (effect.type !== "abandon") continue
-        const result = await jjAbandon(effect.revision ?? effect.bookmark, {
-            observer: options.observer,
-        })
-        if (!result.success) throw new Error(result.stderr || result.stdout)
-        journal.entries.push({
-            type: "BookmarkAbandoned",
-            bookmark: effect.bookmark,
-            prNumber: effect.prNumber,
-        })
-    }
-
-    for (const effect of plan.effects) {
         if (effect.type === "rebase" && effect.to) {
             const result = await jjRebase(effect.bookmark, effect.to, {
                 mode: "branch",
@@ -292,6 +326,7 @@ async function applySyncPlan(
             })
         }
         if (effect.type === "push") {
+            if (pushedBookmarks.has(effect.bookmark)) continue
             const result = await jjGitPushBookmark(effect.bookmark, options)
             if (!result.success) throw new Error(result.stderr || result.stdout)
             journal.entries.push({
@@ -322,6 +357,80 @@ async function applySyncPlan(
             })
         }
     }
+
+    const stackPrNumbers = plan.rows
+        .map((row) => prByBookmark.get(row.row.bookmark.name) ?? row.prNumber)
+        .filter((number): number is number => typeof number === "number")
+    for (const row of plan.rows) {
+        const prNumber = prByBookmark.get(row.row.bookmark.name) ?? row.prNumber
+        if (!prNumber) continue
+        const result = await ghUpsertStackComment(
+            prNumber,
+            renderStackComment(prNumber, stackPrNumbers),
+            options,
+        )
+        if (!result.success) throw new Error(result.stderr || result.stdout)
+        journal.entries.push({ type: "StackCommentUpdated", prNumber })
+    }
+
+    const prToOpen = firstCreatedPrNumber ?? stackPrNumbers[0]
+    if (prToOpen) await ghPrViewWeb(prToOpen, options)
+    return prByBookmark
+}
+
+async function persistStackStateFromPlan(
+    plan: StackPlan<FreshBookmark>,
+    prByBookmark: ReadonlyMap<string, number>,
+) {
+    const previous = await readPersistedStackState()
+    const nextByBookmark = new Map(
+        previous.entries.map((entry) => [entry.bookmark, entry]),
+    )
+    const syncedAt = new Date().toISOString()
+
+    for (const row of plan.rows) {
+        const bookmark = row.row.bookmark
+        const parent = row.desiredBase
+        if (!parent || parent === bookmark.name) continue
+        const isTrunk =
+            row.row.depth === 0 && plan.stackRootName !== bookmark.name
+        if (isTrunk) continue
+        const prNumber = prByBookmark.get(bookmark.name) ?? row.prNumber
+        if (
+            !prNumber &&
+            row.effects.some((effect) => effect.type === "create-pr")
+        ) {
+            continue
+        }
+        const parentRow = plan.rows.find(
+            (candidate) => candidate.row.bookmark.name === parent,
+        )
+        const entry: PersistedStackEntry = {
+            bookmark: bookmark.name,
+            parent,
+            ...(prNumber ? { prNumber } : {}),
+            ...(bookmark.changeId ? { headChangeId: bookmark.changeId } : {}),
+            headCommitId: bookmark.commitId,
+            ...(parentRow?.row.bookmark.changeId
+                ? { parentChangeId: parentRow.row.bookmark.changeId }
+                : {}),
+            ...(parentRow?.row.bookmark.commitId
+                ? { parentCommitId: parentRow.row.bookmark.commitId }
+                : {}),
+            baseRefName: parent,
+            syncedAt,
+        }
+        nextByBookmark.set(bookmark.name, entry)
+    }
+
+    await writePersistedStackState({
+        version: 1,
+        entries: [...nextByBookmark.values()],
+    })
+}
+
+function uniqueStrings(values: readonly string[]): readonly string[] {
+    return [...new Set(values)]
 }
 
 function renderStackComment(
@@ -345,7 +454,7 @@ function renderStackComment(
 interface StackJournalFile {
     version: 1
     id: string
-    kind: "submit" | "sync"
+    kind: "sync"
     stackRootName: string
     beforeOperationId: string
     afterOperationId?: string

--- a/src/stack/executor.ts
+++ b/src/stack/executor.ts
@@ -76,6 +76,7 @@ export const prepareSyncPlan = Effect.fn("Stack.prepareSyncPlan")(
 export const applyStackPlan = Effect.fn("Stack.applyPlan")(
     (plan: StackPlan<FreshBookmark>, options: ApplyStackPlanOptions = {}) =>
         Effect.promise(async () => {
+            if (plan.effects.length === 0) return
             const beforeOp = await fetchOpLogId()
             const journal = stackJournal(plan, beforeOp)
             if (plan.kind === "submit") {
@@ -94,13 +95,13 @@ async function loadFreshState(options: {
     readonly includeClosedPulls: boolean
 }) {
     const preFetchState = options.includeClosedPulls
-        ? await readStackState(options.stackRootName)
+        ? await readStackState()
         : undefined
     const fetchResult = await jjGitFetch({ observer: options.observer })
     if (!fetchResult.success)
         throw new Error(fetchResult.stderr || fetchResult.stdout)
 
-    const freshState = await readStackState(options.stackRootName)
+    const freshState = await readStackState()
     const localBookmarks = reconcileFetchedLocalBookmarks(
         freshState.localBookmarks,
         preFetchState?.stackModel,
@@ -127,7 +128,7 @@ async function loadFreshState(options: {
     return { stackModel, pullRequestsByHead, remoteBookmarksByName }
 }
 
-async function readStackState(stackRootName: string) {
+async function readStackState() {
     const [{ commits }, allBookmarks] = await Promise.all([
         fetchLogPage({ limit: 1000 }),
         fetchBookmarks({ allRemotes: true }),
@@ -145,7 +146,6 @@ async function readStackState(stackRootName: string) {
             bookmarks: localBookmarks,
         }),
     )
-    void stackRootName
     return {
         commits: commitInputs,
         localBookmarks,

--- a/src/stack/executor.ts
+++ b/src/stack/executor.ts
@@ -1,0 +1,302 @@
+import { Effect } from "effect"
+import { type Bookmark, fetchBookmarks } from "../commander/bookmarks"
+import {
+    type GitHubPullRequestSummary,
+    ghListPullRequestsByHead,
+    ghPrClose,
+    ghPrCreate,
+    ghPrEditBase,
+    ghPrViewWeb,
+    ghUpsertStackComment,
+} from "../commander/github"
+import { fetchLogPage } from "../commander/log"
+import type { CommandObserver } from "../commander/observer"
+import {
+    fetchOpLogId,
+    jjGitFetch,
+    jjGitPushBookmark,
+    jjRebase,
+} from "../commander/operations"
+import { getRepoPath } from "../repo"
+import { buildBookmarkStackModel } from "./discovery"
+import type {
+    BookmarkStackModel,
+    StackPlan,
+    StackPlanEffect,
+    StackPullRequestInput,
+} from "./model"
+import { buildSubmitPlanSync, buildSyncPlanSync } from "./planner"
+
+export interface PrepareStackPlanOptions {
+    readonly stackRootName: string
+    readonly observer?: CommandObserver
+}
+
+export interface ApplyStackPlanOptions {
+    readonly observer?: CommandObserver
+}
+
+type FreshBookmark = Bookmark
+
+export const prepareSubmitPlan = Effect.fn("Stack.prepareSubmitPlan")(
+    (options: PrepareStackPlanOptions) =>
+        Effect.promise(async () => {
+            const state = await loadFreshState({
+                observer: options.observer,
+                includeClosedPulls: false,
+            })
+            return buildSubmitPlanSync({
+                stackRootName: options.stackRootName,
+                stackModel: state.stackModel,
+                pullRequestsByHead: state.pullRequestsByHead,
+                remoteBookmarksByName: state.remoteBookmarksByName,
+            })
+        }),
+)
+
+export const prepareSyncPlan = Effect.fn("Stack.prepareSyncPlan")(
+    (options: PrepareStackPlanOptions) =>
+        Effect.promise(async () => {
+            const state = await loadFreshState({
+                observer: options.observer,
+                includeClosedPulls: true,
+            })
+            return buildSyncPlanSync({
+                stackRootName: options.stackRootName,
+                stackModel: state.stackModel,
+                pullRequestsByHead: state.pullRequestsByHead,
+                remoteBookmarksByName: state.remoteBookmarksByName,
+            })
+        }),
+)
+
+export const applyStackPlan = Effect.fn("Stack.applyPlan")(
+    (plan: StackPlan<FreshBookmark>, options: ApplyStackPlanOptions = {}) =>
+        Effect.promise(async () => {
+            const beforeOp = await fetchOpLogId()
+            const journal = stackJournal(plan, beforeOp)
+            if (plan.kind === "submit") {
+                await applySubmitPlan(plan, journal, options)
+            } else {
+                await applySyncPlan(plan, journal, options)
+            }
+            journal.afterOperationId = await fetchOpLogId()
+            await writeJournal(journal)
+        }),
+)
+
+async function loadFreshState(options: {
+    readonly observer?: CommandObserver
+    readonly includeClosedPulls: boolean
+}) {
+    const fetchResult = await jjGitFetch({ observer: options.observer })
+    if (!fetchResult.success)
+        throw new Error(fetchResult.stderr || fetchResult.stdout)
+
+    const [{ commits }, allBookmarks] = await Promise.all([
+        fetchLogPage({ limit: 1000 }),
+        fetchBookmarks({ allRemotes: true }),
+    ])
+    const localBookmarks = allBookmarks.filter((bookmark) => bookmark.isLocal)
+    const remoteBookmarks = allBookmarks.filter((bookmark) => !bookmark.isLocal)
+    const stackModel = Effect.runSync(
+        buildBookmarkStackModel({
+            commits: commits.map((commit) => ({
+                commitId: commit.commitId,
+                parentCommitIds: commit.parentCommitIds ?? [],
+                immutable: commit.immutable,
+            })),
+            bookmarks: localBookmarks,
+        }),
+    )
+    const heads = stackModel.rows.map((row) => row.bookmark.name)
+    const pullRequestsByHead = new Map<string, StackPullRequestInput>(
+        [
+            ...(await ghListPullRequestsByHead(heads, {
+                includeClosed: options.includeClosedPulls,
+            })),
+        ].map(([head, pull]) => [head, pull]),
+    )
+    const remoteBookmarksByName = new Map(
+        remoteBookmarks.map((bookmark) => [bookmark.name, bookmark]),
+    )
+    return { stackModel, pullRequestsByHead, remoteBookmarksByName }
+}
+
+async function applySubmitPlan(
+    plan: StackPlan<FreshBookmark>,
+    journal: StackJournalFile,
+    options: ApplyStackPlanOptions,
+) {
+    const prByBookmark = new Map(
+        plan.rows
+            .filter((row) => row.prNumber)
+            .map((row) => [row.row.bookmark.name, row.prNumber ?? 0]),
+    )
+
+    for (const effect of plan.effects) {
+        if (effect.type === "push") {
+            const result = await jjGitPushBookmark(effect.bookmark, options)
+            if (!result.success) throw new Error(result.stderr || result.stdout)
+            journal.entries.push({
+                type: "BookmarkPushed",
+                bookmark: effect.bookmark,
+            })
+        }
+    }
+
+    for (const row of plan.rows) {
+        const bookmark = row.row.bookmark
+        const createEffect = row.effects.find(
+            (effect) => effect.type === "create-pr",
+        )
+        if (!createEffect) continue
+        const result = await ghPrCreate(
+            {
+                head: bookmark.name,
+                base: row.desiredBase ?? plan.stackRootName,
+                title: bookmark.description || bookmark.name,
+                body: "",
+            },
+            options,
+        )
+        if (!result.success) throw new Error(result.stderr || result.stdout)
+        const fresh = await ghListPullRequestsByHead([bookmark.name])
+        const pull = fresh.get(bookmark.name)
+        if (pull) {
+            prByBookmark.set(bookmark.name, pull.number)
+            journal.entries.push({
+                type: "PrCreated",
+                prNumber: pull.number,
+                head: bookmark.name,
+            })
+        }
+    }
+
+    for (const effect of plan.effects) {
+        if (effect.type !== "update-pr" || !effect.prNumber || !effect.to)
+            continue
+        const result = await ghPrEditBase(effect.prNumber, effect.to, options)
+        if (!result.success) throw new Error(result.stderr || result.stdout)
+        journal.entries.push({
+            type: "PrBaseChanged",
+            prNumber: effect.prNumber,
+            from: effect.from,
+            to: effect.to,
+        })
+    }
+
+    const stackPrNumbers = plan.rows
+        .map((row) => prByBookmark.get(row.row.bookmark.name) ?? row.prNumber)
+        .filter((number): number is number => typeof number === "number")
+    for (const row of plan.rows) {
+        const prNumber = prByBookmark.get(row.row.bookmark.name) ?? row.prNumber
+        if (!prNumber) continue
+        const result = await ghUpsertStackComment(
+            prNumber,
+            renderStackComment(prNumber, stackPrNumbers),
+            options,
+        )
+        if (!result.success) throw new Error(result.stderr || result.stdout)
+        journal.entries.push({ type: "StackCommentUpdated", prNumber })
+    }
+
+    const firstPr = stackPrNumbers[0]
+    if (firstPr) await ghPrViewWeb(firstPr, options)
+}
+
+async function applySyncPlan(
+    plan: StackPlan<FreshBookmark>,
+    journal: StackJournalFile,
+    options: ApplyStackPlanOptions,
+) {
+    for (const effect of plan.effects) {
+        if (effect.type === "rebase" && effect.to) {
+            const result = await jjRebase(effect.bookmark, effect.to, {
+                mode: "branch",
+                skipEmptied: true,
+                observer: options.observer,
+            })
+            if (!result.success) throw new Error(result.stderr || result.stdout)
+            journal.entries.push({
+                type: "BookmarkRebased",
+                bookmark: effect.bookmark,
+                from: effect.from,
+                to: effect.to,
+            })
+        }
+        if (effect.type === "close-pr" && effect.prNumber) {
+            const result = await ghPrClose(effect.prNumber, options)
+            if (!result.success) throw new Error(result.stderr || result.stdout)
+            journal.entries.push({
+                type: "PrClosed",
+                prNumber: effect.prNumber,
+            })
+        }
+    }
+}
+
+function renderStackComment(
+    currentPr: number,
+    stackPrNumbers: readonly number[],
+) {
+    return [
+        `<!-- kajji-stack pr=${currentPr} -->`,
+        "",
+        "### Stack",
+        "",
+        ...stackPrNumbers.map(
+            (number, index) =>
+                `${index + 1}. #${number}${number === currentPr ? " 👈" : ""}`,
+        ),
+        "",
+        "This stack is managed by [kajji](https://github.com/eliaskc/kajji).",
+    ].join("\n")
+}
+
+interface StackJournalFile {
+    version: 1
+    id: string
+    kind: "submit" | "sync"
+    stackRootName: string
+    beforeOperationId: string
+    afterOperationId?: string
+    createdAt: string
+    entries: Array<Record<string, unknown>>
+}
+
+function stackJournal(
+    plan: StackPlan<FreshBookmark>,
+    beforeOperationId: string,
+): StackJournalFile {
+    return {
+        version: 1,
+        id: crypto.randomUUID(),
+        kind: plan.kind,
+        stackRootName: plan.stackRootName,
+        beforeOperationId,
+        createdAt: new Date().toISOString(),
+        entries: [],
+    }
+}
+
+async function writeJournal(journal: StackJournalFile) {
+    const dir = `${stackJournalRoot()}/${repoCacheKey()}`
+    await import("node:fs/promises").then((fs) =>
+        fs.mkdir(dir, { recursive: true }),
+    )
+    await Bun.write(
+        `${dir}/${journal.id}.json`,
+        `${JSON.stringify(journal, null, 2)}\n`,
+    )
+}
+
+function stackJournalRoot() {
+    const cacheHome =
+        process.env.XDG_CACHE_HOME || `${process.env.HOME ?? ""}/.cache`
+    return `${cacheHome}/kajji/stack-journal`
+}
+
+function repoCacheKey() {
+    return Buffer.from(getRepoPath()).toString("base64url")
+}

--- a/src/stack/executor.ts
+++ b/src/stack/executor.ts
@@ -197,6 +197,8 @@ async function applySubmitPlan(
         }
     }
 
+    let firstCreatedPrNumber: number | undefined
+
     for (const row of plan.rows) {
         const bookmark = row.row.bookmark
         const createEffect = row.effects.find(
@@ -215,6 +217,7 @@ async function applySubmitPlan(
         const pull = fresh.get(bookmark.name)
         if (pull) {
             prByBookmark.set(bookmark.name, pull.number)
+            firstCreatedPrNumber ??= pull.number
             journal.entries.push({
                 type: "PrCreated",
                 prNumber: pull.number,
@@ -251,8 +254,8 @@ async function applySubmitPlan(
         journal.entries.push({ type: "StackCommentUpdated", prNumber })
     }
 
-    const firstPr = stackPrNumbers[0]
-    if (firstPr) await ghPrViewWeb(firstPr, options)
+    const prToOpen = firstCreatedPrNumber ?? stackPrNumbers[0]
+    if (prToOpen) await ghPrViewWeb(prToOpen, options)
 }
 
 async function applySyncPlan(

--- a/src/stack/executor.ts
+++ b/src/stack/executor.ts
@@ -43,6 +43,7 @@ export const prepareSubmitPlan = Effect.fn("Stack.prepareSubmitPlan")(
     (options: PrepareStackPlanOptions) =>
         Effect.promise(async () => {
             const state = await loadFreshState({
+                stackRootName: options.stackRootName,
                 observer: options.observer,
                 includeClosedPulls: false,
             })
@@ -59,6 +60,7 @@ export const prepareSyncPlan = Effect.fn("Stack.prepareSyncPlan")(
     (options: PrepareStackPlanOptions) =>
         Effect.promise(async () => {
             const state = await loadFreshState({
+                stackRootName: options.stackRootName,
                 observer: options.observer,
                 includeClosedPulls: true,
             })
@@ -87,26 +89,27 @@ export const applyStackPlan = Effect.fn("Stack.applyPlan")(
 )
 
 async function loadFreshState(options: {
+    readonly stackRootName: string
     readonly observer?: CommandObserver
     readonly includeClosedPulls: boolean
 }) {
+    const preFetchState = options.includeClosedPulls
+        ? await readStackState(options.stackRootName)
+        : undefined
     const fetchResult = await jjGitFetch({ observer: options.observer })
     if (!fetchResult.success)
         throw new Error(fetchResult.stderr || fetchResult.stdout)
 
-    const [{ commits }, allBookmarks] = await Promise.all([
-        fetchLogPage({ limit: 1000 }),
-        fetchBookmarks({ allRemotes: true }),
-    ])
-    const localBookmarks = allBookmarks.filter((bookmark) => bookmark.isLocal)
-    const remoteBookmarks = allBookmarks.filter((bookmark) => !bookmark.isLocal)
+    const freshState = await readStackState(options.stackRootName)
+    const localBookmarks = reconcileFetchedLocalBookmarks(
+        freshState.localBookmarks,
+        preFetchState?.stackModel,
+        options.stackRootName,
+    )
+    const remoteBookmarks = freshState.remoteBookmarks
     const stackModel = Effect.runSync(
         buildBookmarkStackModel({
-            commits: commits.map((commit) => ({
-                commitId: commit.commitId,
-                parentCommitIds: commit.parentCommitIds ?? [],
-                immutable: commit.immutable,
-            })),
+            commits: freshState.commits,
             bookmarks: localBookmarks,
         }),
     )
@@ -122,6 +125,54 @@ async function loadFreshState(options: {
         remoteBookmarks.map((bookmark) => [bookmark.name, bookmark]),
     )
     return { stackModel, pullRequestsByHead, remoteBookmarksByName }
+}
+
+async function readStackState(stackRootName: string) {
+    const [{ commits }, allBookmarks] = await Promise.all([
+        fetchLogPage({ limit: 1000 }),
+        fetchBookmarks({ allRemotes: true }),
+    ])
+    const localBookmarks = allBookmarks.filter((bookmark) => bookmark.isLocal)
+    const remoteBookmarks = allBookmarks.filter((bookmark) => !bookmark.isLocal)
+    const commitInputs = commits.map((commit) => ({
+        commitId: commit.commitId,
+        parentCommitIds: commit.parentCommitIds ?? [],
+        immutable: commit.immutable,
+    }))
+    const stackModel = Effect.runSync(
+        buildBookmarkStackModel({
+            commits: commitInputs,
+            bookmarks: localBookmarks,
+        }),
+    )
+    void stackRootName
+    return {
+        commits: commitInputs,
+        localBookmarks,
+        remoteBookmarks,
+        stackModel,
+    }
+}
+
+function reconcileFetchedLocalBookmarks(
+    localBookmarks: readonly FreshBookmark[],
+    preFetchStackModel: BookmarkStackModel<FreshBookmark> | undefined,
+    stackRootName: string,
+): readonly FreshBookmark[] {
+    if (!preFetchStackModel) return localBookmarks
+    if (localBookmarks.some((bookmark) => bookmark.name === stackRootName)) {
+        return localBookmarks
+    }
+    const preFetchRows = preFetchStackModel.rows.filter((row) =>
+        row.stackKeys.includes(stackRootName),
+    )
+    if (preFetchRows.length === 0) return localBookmarks
+    const localNames = new Set(localBookmarks.map((bookmark) => bookmark.name))
+    const restoredBookmarks = preFetchRows
+        .map((row) => row.bookmark)
+        .filter((bookmark) => !localNames.has(bookmark.name))
+    if (restoredBookmarks.length === 0) return localBookmarks
+    return [...localBookmarks, ...restoredBookmarks]
 }
 
 async function applySubmitPlan(
@@ -212,6 +263,19 @@ async function applySyncPlan(
     options: ApplyStackPlanOptions,
 ) {
     for (const effect of plan.effects) {
+        if (effect.type !== "abandon") continue
+        const result = await jjAbandon(effect.revision ?? effect.bookmark, {
+            observer: options.observer,
+        })
+        if (!result.success) throw new Error(result.stderr || result.stdout)
+        journal.entries.push({
+            type: "BookmarkAbandoned",
+            bookmark: effect.bookmark,
+            prNumber: effect.prNumber,
+        })
+    }
+
+    for (const effect of plan.effects) {
         if (effect.type === "rebase" && effect.to) {
             const result = await jjRebase(effect.bookmark, effect.to, {
                 mode: "branch",
@@ -256,19 +320,6 @@ async function applySyncPlan(
                 prNumber: effect.prNumber,
             })
         }
-    }
-
-    for (const effect of plan.effects) {
-        if (effect.type !== "abandon") continue
-        const result = await jjAbandon(effect.bookmark, {
-            observer: options.observer,
-        })
-        if (!result.success) throw new Error(result.stderr || result.stdout)
-        journal.entries.push({
-            type: "BookmarkAbandoned",
-            bookmark: effect.bookmark,
-            prNumber: effect.prNumber,
-        })
     }
 }
 

--- a/src/stack/executor.ts
+++ b/src/stack/executor.ts
@@ -13,6 +13,7 @@ import { fetchLogPage } from "../commander/log"
 import type { CommandObserver } from "../commander/observer"
 import {
     fetchOpLogId,
+    jjAbandon,
     jjGitFetch,
     jjGitPushBookmark,
     jjRebase,
@@ -225,6 +226,28 @@ async function applySyncPlan(
                 to: effect.to,
             })
         }
+        if (effect.type === "push") {
+            const result = await jjGitPushBookmark(effect.bookmark, options)
+            if (!result.success) throw new Error(result.stderr || result.stdout)
+            journal.entries.push({
+                type: "BookmarkPushed",
+                bookmark: effect.bookmark,
+            })
+        }
+        if (effect.type === "update-pr" && effect.prNumber && effect.to) {
+            const result = await ghPrEditBase(
+                effect.prNumber,
+                effect.to,
+                options,
+            )
+            if (!result.success) throw new Error(result.stderr || result.stdout)
+            journal.entries.push({
+                type: "PrBaseChanged",
+                prNumber: effect.prNumber,
+                from: effect.from,
+                to: effect.to,
+            })
+        }
         if (effect.type === "close-pr" && effect.prNumber) {
             const result = await ghPrClose(effect.prNumber, options)
             if (!result.success) throw new Error(result.stderr || result.stdout)
@@ -233,6 +256,19 @@ async function applySyncPlan(
                 prNumber: effect.prNumber,
             })
         }
+    }
+
+    for (const effect of plan.effects) {
+        if (effect.type !== "abandon") continue
+        const result = await jjAbandon(effect.bookmark, {
+            observer: options.observer,
+        })
+        if (!result.success) throw new Error(result.stderr || result.stdout)
+        journal.entries.push({
+            type: "BookmarkAbandoned",
+            bookmark: effect.bookmark,
+            prNumber: effect.prNumber,
+        })
     }
 }
 

--- a/src/stack/executor.ts
+++ b/src/stack/executor.ts
@@ -207,8 +207,6 @@ async function applySubmitPlan(
             {
                 head: bookmark.name,
                 base: row.desiredBase ?? plan.stackRootName,
-                title: bookmark.description || bookmark.name,
-                body: "",
             },
             options,
         )

--- a/src/stack/executor.ts
+++ b/src/stack/executor.ts
@@ -313,7 +313,7 @@ async function applySyncPlan(
     for (const effect of plan.effects) {
         if (effect.type === "rebase" && effect.to) {
             const result = await jjRebase(effect.bookmark, effect.to, {
-                mode: "branch",
+                mode: "descendants",
                 skipEmptied: true,
                 observer: options.observer,
             })

--- a/src/stack/model.ts
+++ b/src/stack/model.ts
@@ -24,3 +24,41 @@ export interface BookmarkStackModel<TBookmark extends StackBookmarkInput> {
     readonly trunkNames: ReadonlySet<string>
     readonly stackRootNames: ReadonlySet<string>
 }
+
+export interface StackPullRequestInput {
+    readonly number: number
+    readonly headRefName: string
+    readonly baseRefName?: string
+}
+
+export interface StackRemoteBookmarkInput {
+    readonly name: string
+    readonly commitId: string
+}
+
+export type StackPlanKind = "submit" | "sync"
+export type StackPlanRowStatus =
+    | "current"
+    | "create-pr"
+    | "update-pr"
+    | "push"
+    | "rebase"
+
+export interface StackPlanRow<TBookmark extends StackBookmarkInput> {
+    readonly row: BookmarkStackRow<TBookmark>
+    readonly prNumber?: number
+    readonly desiredBase?: string
+    readonly status: StackPlanRowStatus
+    readonly note: string
+}
+
+export interface StackPlan<TBookmark extends StackBookmarkInput> {
+    readonly kind: StackPlanKind
+    readonly stackRootName: string
+    readonly rows: readonly StackPlanRow<TBookmark>[]
+    readonly updatePrNumbers: readonly number[]
+    readonly createPrBookmarks: readonly string[]
+    readonly pushBookmarks: readonly string[]
+    readonly rebaseBookmarks: readonly string[]
+    readonly applyCommand: string
+}

--- a/src/stack/model.ts
+++ b/src/stack/model.ts
@@ -45,6 +45,7 @@ export type StackPlanEffectType =
     | "update-pr"
     | "push"
     | "rebase"
+    | "abandon"
     | "update-comment"
     | "close-pr"
     | "blocked"
@@ -78,6 +79,7 @@ export interface StackPlan<TBookmark extends StackBookmarkInput> {
     readonly createPrBookmarks: readonly string[]
     readonly pushBookmarks: readonly string[]
     readonly rebaseBookmarks: readonly string[]
+    readonly abandonBookmarks: readonly string[]
     readonly closePrNumbers: readonly number[]
     readonly applyCommand: string
 }

--- a/src/stack/model.ts
+++ b/src/stack/model.ts
@@ -57,6 +57,7 @@ export interface StackPlanEffect {
     readonly from?: string
     readonly to?: string
     readonly reason?: string
+    readonly revision?: string
 }
 
 export type StackPlanRowStatus = "current" | StackPlanEffectType

--- a/src/stack/model.ts
+++ b/src/stack/model.ts
@@ -1,0 +1,26 @@
+export interface StackCommitInput {
+    readonly commitId: string
+    readonly parentCommitIds?: readonly string[]
+    readonly immutable: boolean
+}
+
+export interface StackBookmarkInput {
+    readonly name: string
+    readonly commitId: string
+    readonly changeId?: string
+}
+
+export interface BookmarkStackRow<TBookmark extends StackBookmarkInput> {
+    readonly bookmark: TBookmark
+    readonly depth: number
+    /** Stack roots this row belongs to. Trunk rows can belong to multiple stacks. */
+    readonly stackKeys: readonly string[]
+}
+
+export interface BookmarkStackModel<TBookmark extends StackBookmarkInput> {
+    readonly rows: readonly BookmarkStackRow<TBookmark>[]
+    readonly parentByName: ReadonlyMap<string, string>
+    readonly childrenByName: ReadonlyMap<string, readonly TBookmark[]>
+    readonly trunkNames: ReadonlySet<string>
+    readonly stackRootNames: ReadonlySet<string>
+}

--- a/src/stack/model.ts
+++ b/src/stack/model.ts
@@ -8,6 +8,7 @@ export interface StackBookmarkInput {
     readonly name: string
     readonly commitId: string
     readonly changeId?: string
+    readonly description?: string
 }
 
 export interface BookmarkStackRow<TBookmark extends StackBookmarkInput> {
@@ -29,6 +30,8 @@ export interface StackPullRequestInput {
     readonly number: number
     readonly headRefName: string
     readonly baseRefName?: string
+    readonly state?: string
+    readonly merged?: boolean
 }
 
 export interface StackRemoteBookmarkInput {
@@ -37,12 +40,25 @@ export interface StackRemoteBookmarkInput {
 }
 
 export type StackPlanKind = "submit" | "sync"
-export type StackPlanRowStatus =
-    | "current"
+export type StackPlanEffectType =
     | "create-pr"
     | "update-pr"
     | "push"
     | "rebase"
+    | "update-comment"
+    | "close-pr"
+    | "blocked"
+
+export interface StackPlanEffect {
+    readonly type: StackPlanEffectType
+    readonly bookmark: string
+    readonly prNumber?: number
+    readonly from?: string
+    readonly to?: string
+    readonly reason?: string
+}
+
+export type StackPlanRowStatus = "current" | StackPlanEffectType
 
 export interface StackPlanRow<TBookmark extends StackBookmarkInput> {
     readonly row: BookmarkStackRow<TBookmark>
@@ -50,15 +66,18 @@ export interface StackPlanRow<TBookmark extends StackBookmarkInput> {
     readonly desiredBase?: string
     readonly status: StackPlanRowStatus
     readonly note: string
+    readonly effects: readonly StackPlanEffect[]
 }
 
 export interface StackPlan<TBookmark extends StackBookmarkInput> {
     readonly kind: StackPlanKind
     readonly stackRootName: string
     readonly rows: readonly StackPlanRow<TBookmark>[]
+    readonly effects: readonly StackPlanEffect[]
     readonly updatePrNumbers: readonly number[]
     readonly createPrBookmarks: readonly string[]
     readonly pushBookmarks: readonly string[]
     readonly rebaseBookmarks: readonly string[]
+    readonly closePrNumbers: readonly number[]
     readonly applyCommand: string
 }

--- a/src/stack/model.ts
+++ b/src/stack/model.ts
@@ -39,13 +39,14 @@ export interface StackRemoteBookmarkInput {
     readonly commitId: string
 }
 
-export type StackPlanKind = "submit" | "sync"
+export type StackPlanKind = "sync"
 export type StackPlanEffectType =
     | "create-pr"
     | "update-pr"
     | "push"
     | "rebase"
     | "abandon"
+    | "abandon-landed-range"
     | "update-comment"
     | "close-pr"
     | "blocked"
@@ -58,6 +59,7 @@ export interface StackPlanEffect {
     readonly to?: string
     readonly reason?: string
     readonly revision?: string
+    readonly range?: string
 }
 
 export type StackPlanRowStatus = "current" | StackPlanEffectType

--- a/src/stack/planner.ts
+++ b/src/stack/planner.ts
@@ -175,6 +175,7 @@ export function buildSyncPlanSync<TBookmark extends StackBookmarkInput>({
                     bookmark: bookmark.name,
                     prNumber: pull.number,
                     reason: "PR was merged",
+                    revision: bookmark.changeId ?? bookmark.name,
                 })
             }
             if (desiredBase !== localBase) {

--- a/src/stack/planner.ts
+++ b/src/stack/planner.ts
@@ -39,6 +39,10 @@ export function buildSyncPlanSync<TBookmark extends StackBookmarkInput>({
     const effects: StackPlanEffect[] = []
     let blockedByClosedUnmerged: StackPullRequestInput | undefined
     const mergedTargetByName = new Map<string, string>()
+    const stackHasMergedPull = rows.some(
+        (row) => pullRequestsByHead.get(row.bookmark.name)?.merged === true,
+    )
+    const rebasedBranchNames = new Set<string>()
 
     for (const row of rows) {
         const bookmark = row.bookmark
@@ -110,16 +114,22 @@ export function buildSyncPlanSync<TBookmark extends StackBookmarkInput>({
                     bookmark.name,
                     pull.baseRefName ?? localBase,
                 )
-                rowEffects.push({
-                    type: "abandon",
-                    bookmark: bookmark.name,
-                    prNumber: pull.number,
-                    reason: "PR was merged",
-                    revision: `${desiredBase}..${bookmark.changeId ?? bookmark.name}`,
-                })
+                if (!remote) {
+                    rowEffects.push({
+                        type: "abandon",
+                        bookmark: bookmark.name,
+                        prNumber: pull.number,
+                        reason: "PR was merged and remote bookmark is gone",
+                        revision: `${desiredBase}..${bookmark.changeId ?? bookmark.name}`,
+                    })
+                }
             }
             const landedRange = landedRangesByBookmark.get(bookmark.name)
-            if (landedRange) {
+            if (
+                landedRange &&
+                pull?.merged !== true &&
+                !mergedTargetByName.has(localBase)
+            ) {
                 rowEffects.push({
                     type: "abandon-landed-range",
                     bookmark: bookmark.name,
@@ -128,7 +138,16 @@ export function buildSyncPlanSync<TBookmark extends StackBookmarkInput>({
                     reason: "parent PR was merged outside kajji",
                 })
             }
-            if (pull && needsPush && pull.merged !== true) {
+            if (
+                pull &&
+                needsPush &&
+                pull.merged !== true &&
+                desiredBase === localBase &&
+                !rebasedBranchNames.has(localBase)
+            ) {
+                rowEffects.push({ type: "push", bookmark: bookmark.name })
+            }
+            if (rebasedBranchNames.has(localBase) && pull?.merged !== true) {
                 rowEffects.push({ type: "push", bookmark: bookmark.name })
             }
             if (desiredBase !== localBase) {
@@ -139,10 +158,13 @@ export function buildSyncPlanSync<TBookmark extends StackBookmarkInput>({
                     from: localBase,
                     to: desiredBase,
                 })
-                rowEffects.push({
-                    type: "push",
-                    bookmark: bookmark.name,
-                })
+                if (!rowEffects.some((effect) => effect.type === "push")) {
+                    rowEffects.push({
+                        type: "push",
+                        bookmark: bookmark.name,
+                    })
+                }
+                rebasedBranchNames.add(bookmark.name)
             }
             if (
                 pull?.number &&
@@ -161,7 +183,8 @@ export function buildSyncPlanSync<TBookmark extends StackBookmarkInput>({
             if (
                 pull?.number &&
                 pull.state !== "CLOSED" &&
-                pull.state !== "MERGED"
+                pull.state !== "MERGED" &&
+                !stackHasMergedPull
             ) {
                 rowEffects.push({
                     type: "update-comment",
@@ -210,29 +233,34 @@ function makePlan<TBookmark extends StackBookmarkInput>(
     effects: readonly StackPlanEffect[],
     applyCommand: string,
 ): StackPlan<TBookmark> {
+    const orderedEffects = orderStackEffects(effects)
     return {
         kind,
         stackRootName,
         rows,
-        effects,
+        effects: orderedEffects,
         updatePrNumbers: uniqueNumbers(
-            effects
+            orderedEffects
                 .filter((e) => e.type === "update-pr" && e.prNumber)
                 .map((e) => e.prNumber ?? 0),
         ),
         createPrBookmarks: uniqueStrings(
-            effects
+            orderedEffects
                 .filter((e) => e.type === "create-pr")
                 .map((e) => e.bookmark),
         ),
         pushBookmarks: uniqueStrings(
-            effects.filter((e) => e.type === "push").map((e) => e.bookmark),
+            orderedEffects
+                .filter((e) => e.type === "push")
+                .map((e) => e.bookmark),
         ),
         rebaseBookmarks: uniqueStrings(
-            effects.filter((e) => e.type === "rebase").map((e) => e.bookmark),
+            orderedEffects
+                .filter((e) => e.type === "rebase")
+                .map((e) => e.bookmark),
         ),
         abandonBookmarks: uniqueStrings(
-            effects
+            orderedEffects
                 .filter(
                     (e) =>
                         e.type === "abandon" ||
@@ -241,11 +269,46 @@ function makePlan<TBookmark extends StackBookmarkInput>(
                 .map((e) => e.bookmark),
         ),
         closePrNumbers: uniqueNumbers(
-            effects
+            orderedEffects
                 .filter((e) => e.type === "close-pr" && e.prNumber)
                 .map((e) => e.prNumber ?? 0),
         ),
         applyCommand,
+    }
+}
+
+function orderStackEffects(
+    effects: readonly StackPlanEffect[],
+): readonly StackPlanEffect[] {
+    return effects
+        .map((effect, index) => ({ effect, index }))
+        .sort((a, b) => {
+            const priorityDiff =
+                stackEffectPriority(a.effect) - stackEffectPriority(b.effect)
+            return priorityDiff || a.index - b.index
+        })
+        .map(({ effect }) => effect)
+}
+
+function stackEffectPriority(effect: StackPlanEffect) {
+    switch (effect.type) {
+        case "blocked":
+            return 0
+        case "close-pr":
+            return 10
+        case "abandon":
+        case "abandon-landed-range":
+            return 20
+        case "rebase":
+            return 30
+        case "push":
+            return 40
+        case "create-pr":
+            return 50
+        case "update-pr":
+            return 60
+        case "update-comment":
+            return 70
     }
 }
 

--- a/src/stack/planner.ts
+++ b/src/stack/planner.ts
@@ -18,13 +18,8 @@ export interface BuildStackPlanOptions<TBookmark extends StackBookmarkInput> {
         string,
         StackRemoteBookmarkInput
     >
+    readonly landedRangesByBookmark?: ReadonlyMap<string, string>
 }
-
-export const buildSubmitPlan = Effect.fn("Stack.plan.submit")(
-    <TBookmark extends StackBookmarkInput>(
-        options: BuildStackPlanOptions<TBookmark>,
-    ) => Effect.succeed(buildSubmitPlanSync(options)),
-)
 
 export const buildSyncPlan = Effect.fn("Stack.plan.sync")(
     <TBookmark extends StackBookmarkInput>(
@@ -32,80 +27,12 @@ export const buildSyncPlan = Effect.fn("Stack.plan.sync")(
     ) => Effect.succeed(buildSyncPlanSync(options)),
 )
 
-export function buildSubmitPlanSync<TBookmark extends StackBookmarkInput>({
-    stackRootName,
-    stackModel,
-    pullRequestsByHead,
-    remoteBookmarksByName = new Map(),
-}: BuildStackPlanOptions<TBookmark>): StackPlan<TBookmark> {
-    const rows = stackRows(stackRootName, stackModel)
-    const planRows: StackPlanRow<TBookmark>[] = []
-    const effects: StackPlanEffect[] = []
-
-    for (const row of rows) {
-        const bookmark = row.bookmark
-        const desiredBase = desiredLocalBase(bookmark.name, stackModel)
-        const pull = pullRequestsByHead.get(bookmark.name)
-        const remote = remoteBookmarksByName.get(bookmark.name)
-        const isTrunk = stackModel.trunkNames.has(bookmark.name)
-        const rowEffects: StackPlanEffect[] = []
-        const needsPush = Boolean(
-            !isTrunk &&
-                bookmark.commitId &&
-                (!remote || remote.commitId !== bookmark.commitId),
-        )
-
-        if (isTrunk) {
-            planRows.push(rowPlan(row, pull, desiredBase, rowEffects, ""))
-            continue
-        }
-
-        if (needsPush) {
-            rowEffects.push({ type: "push", bookmark: bookmark.name })
-        }
-
-        if (!pull) {
-            rowEffects.push({
-                type: "create-pr",
-                bookmark: bookmark.name,
-                to: desiredBase,
-            })
-        } else {
-            if (pull.baseRefName && pull.baseRefName !== desiredBase) {
-                rowEffects.push({
-                    type: "update-pr",
-                    bookmark: bookmark.name,
-                    prNumber: pull.number,
-                    from: pull.baseRefName,
-                    to: desiredBase,
-                })
-            }
-            rowEffects.push({
-                type: "update-comment",
-                bookmark: bookmark.name,
-                prNumber: pull.number,
-            })
-        }
-
-        effects.push(...rowEffects)
-        planRows.push(
-            rowPlan(
-                row,
-                pull,
-                desiredBase,
-                rowEffects,
-                submitNote(rowEffects, desiredBase),
-            ),
-        )
-    }
-
-    return makePlan("submit", stackRootName, planRows, effects, "stack submit")
-}
-
 export function buildSyncPlanSync<TBookmark extends StackBookmarkInput>({
     stackRootName,
     stackModel,
     pullRequestsByHead,
+    remoteBookmarksByName = new Map(),
+    landedRangesByBookmark = new Map(),
 }: BuildStackPlanOptions<TBookmark>): StackPlan<TBookmark> {
     const rows = stackRows(stackRootName, stackModel)
     const planRows: StackPlanRow<TBookmark>[] = []
@@ -118,10 +45,15 @@ export function buildSyncPlanSync<TBookmark extends StackBookmarkInput>({
         const pull = pullRequestsByHead.get(bookmark.name)
         const localBase = desiredLocalBase(bookmark.name, stackModel)
         const inheritedMergedTarget = mergedTargetByName.get(localBase)
-        const desiredBase =
-            inheritedMergedTarget ?? pull?.baseRefName ?? localBase
+        const desiredBase = inheritedMergedTarget ?? localBase
         const isTrunk = stackModel.trunkNames.has(bookmark.name)
+        const remote = remoteBookmarksByName.get(bookmark.name)
         const rowEffects: StackPlanEffect[] = []
+        const needsPush = Boolean(
+            !isTrunk &&
+                bookmark.commitId &&
+                (!remote || remote.commitId !== bookmark.commitId),
+        )
 
         if (isTrunk) {
             planRows.push(rowPlan(row, pull, desiredBase, rowEffects, ""))
@@ -165,7 +97,15 @@ export function buildSyncPlanSync<TBookmark extends StackBookmarkInput>({
                 reason: "PR was closed without merging",
             })
         } else {
-            if (pull?.merged === true) {
+            if (!pull) {
+                if (needsPush)
+                    rowEffects.push({ type: "push", bookmark: bookmark.name })
+                rowEffects.push({
+                    type: "create-pr",
+                    bookmark: bookmark.name,
+                    to: desiredBase,
+                })
+            } else if (pull.merged === true) {
                 mergedTargetByName.set(
                     bookmark.name,
                     pull.baseRefName ?? localBase,
@@ -177,6 +117,19 @@ export function buildSyncPlanSync<TBookmark extends StackBookmarkInput>({
                     reason: "PR was merged",
                     revision: `${desiredBase}..${bookmark.changeId ?? bookmark.name}`,
                 })
+            }
+            const landedRange = landedRangesByBookmark.get(bookmark.name)
+            if (landedRange) {
+                rowEffects.push({
+                    type: "abandon-landed-range",
+                    bookmark: bookmark.name,
+                    prNumber: pull?.number,
+                    range: landedRange,
+                    reason: "parent PR was merged outside kajji",
+                })
+            }
+            if (pull && needsPush && pull.merged !== true) {
+                rowEffects.push({ type: "push", bookmark: bookmark.name })
             }
             if (desiredBase !== localBase) {
                 rowEffects.push({
@@ -203,6 +156,17 @@ export function buildSyncPlanSync<TBookmark extends StackBookmarkInput>({
                     prNumber: pull.number,
                     from: pull.baseRefName,
                     to: desiredBase,
+                })
+            }
+            if (
+                pull?.number &&
+                pull.state !== "CLOSED" &&
+                pull.state !== "MERGED"
+            ) {
+                rowEffects.push({
+                    type: "update-comment",
+                    bookmark: bookmark.name,
+                    prNumber: pull.number,
                 })
             }
         }
@@ -240,7 +204,7 @@ function rowPlan<TBookmark extends StackBookmarkInput>(
 }
 
 function makePlan<TBookmark extends StackBookmarkInput>(
-    kind: "submit" | "sync",
+    kind: "sync",
     stackRootName: string,
     rows: readonly StackPlanRow<TBookmark>[],
     effects: readonly StackPlanEffect[],
@@ -268,7 +232,13 @@ function makePlan<TBookmark extends StackBookmarkInput>(
             effects.filter((e) => e.type === "rebase").map((e) => e.bookmark),
         ),
         abandonBookmarks: uniqueStrings(
-            effects.filter((e) => e.type === "abandon").map((e) => e.bookmark),
+            effects
+                .filter(
+                    (e) =>
+                        e.type === "abandon" ||
+                        e.type === "abandon-landed-range",
+                )
+                .map((e) => e.bookmark),
         ),
         closePrNumbers: uniqueNumbers(
             effects
@@ -277,20 +247,6 @@ function makePlan<TBookmark extends StackBookmarkInput>(
         ),
         applyCommand,
     }
-}
-
-function submitNote(effects: readonly StackPlanEffect[], desiredBase: string) {
-    if (effects.some((effect) => effect.type === "create-pr")) {
-        return `would create PR onto ${desiredBase}`
-    }
-    if (effects.some((effect) => effect.type === "update-pr")) {
-        return `would retarget PR onto ${desiredBase}`
-    }
-    if (effects.some((effect) => effect.type === "push"))
-        return "would push bookmark"
-    if (effects.some((effect) => effect.type === "update-comment"))
-        return "would update stack comment"
-    return `targets ${desiredBase}`
 }
 
 function syncNote(effects: readonly StackPlanEffect[], desiredBase: string) {
@@ -304,18 +260,31 @@ function syncNote(effects: readonly StackPlanEffect[], desiredBase: string) {
     if (blocked) {
         return blocked.reason ? `blocked: ${blocked.reason}` : "blocked"
     }
-    const abandons = effects.some((effect) => effect.type === "abandon")
+    const creates = effects.some((effect) => effect.type === "create-pr")
+    const comments = effects.some((effect) => effect.type === "update-comment")
+    const abandons = effects.some(
+        (effect) =>
+            effect.type === "abandon" || effect.type === "abandon-landed-range",
+    )
     const rebases = effects.some((effect) => effect.type === "rebase")
     const pushes = effects.some((effect) => effect.type === "push")
     const retargets = effects.some((effect) => effect.type === "update-pr")
+    if (effects.some((effect) => effect.type === "abandon-landed-range"))
+        return "would abandon landed parent range"
     if (abandons) return "would abandon merged local change"
+    if (creates && pushes) return `would push and create PR onto ${desiredBase}`
+    if (creates) return `would create PR onto ${desiredBase}`
     if (rebases && retargets && pushes)
         return `would rebase, push, and retarget onto ${desiredBase}`
     if (rebases && retargets)
         return `would rebase and retarget onto ${desiredBase}`
     if (rebases && pushes) return `would rebase and push onto ${desiredBase}`
     if (rebases) return `would rebase onto ${desiredBase}`
+    if (retargets && pushes)
+        return `would push and retarget PR onto ${desiredBase}`
     if (retargets) return `would retarget PR onto ${desiredBase}`
+    if (pushes) return "would push"
+    if (comments) return "would update stack comment"
     return `targets ${desiredBase}`
 }
 

--- a/src/stack/planner.ts
+++ b/src/stack/planner.ts
@@ -111,12 +111,15 @@ export function buildSyncPlanSync<TBookmark extends StackBookmarkInput>({
     const planRows: StackPlanRow<TBookmark>[] = []
     const effects: StackPlanEffect[] = []
     let blockedByClosedUnmerged: StackPullRequestInput | undefined
+    const mergedTargetByName = new Map<string, string>()
 
     for (const row of rows) {
         const bookmark = row.bookmark
         const pull = pullRequestsByHead.get(bookmark.name)
         const localBase = desiredLocalBase(bookmark.name, stackModel)
-        const desiredBase = pull?.baseRefName ?? localBase
+        const inheritedMergedTarget = mergedTargetByName.get(localBase)
+        const desiredBase =
+            inheritedMergedTarget ?? pull?.baseRefName ?? localBase
         const isTrunk = stackModel.trunkNames.has(bookmark.name)
         const rowEffects: StackPlanEffect[] = []
 
@@ -126,7 +129,7 @@ export function buildSyncPlanSync<TBookmark extends StackBookmarkInput>({
         }
 
         if (blockedByClosedUnmerged) {
-            if (pull?.number && pull.state === "OPEN") {
+            if (pull?.number && pull.state !== "CLOSED") {
                 rowEffects.push({
                     type: "close-pr",
                     bookmark: bookmark.name,
@@ -161,14 +164,46 @@ export function buildSyncPlanSync<TBookmark extends StackBookmarkInput>({
                 prNumber: pull.number,
                 reason: "PR was closed without merging",
             })
-        } else if (desiredBase !== localBase) {
-            rowEffects.push({
-                type: "rebase",
-                bookmark: bookmark.name,
-                prNumber: pull?.number,
-                from: localBase,
-                to: desiredBase,
-            })
+        } else {
+            if (pull?.merged === true) {
+                mergedTargetByName.set(
+                    bookmark.name,
+                    pull.baseRefName ?? localBase,
+                )
+                rowEffects.push({
+                    type: "abandon",
+                    bookmark: bookmark.name,
+                    prNumber: pull.number,
+                    reason: "PR was merged",
+                })
+            }
+            if (desiredBase !== localBase) {
+                rowEffects.push({
+                    type: "rebase",
+                    bookmark: bookmark.name,
+                    prNumber: pull?.number,
+                    from: localBase,
+                    to: desiredBase,
+                })
+                rowEffects.push({
+                    type: "push",
+                    bookmark: bookmark.name,
+                })
+            }
+            if (
+                pull?.number &&
+                pull.state !== "CLOSED" &&
+                pull.state !== "MERGED" &&
+                pull.baseRefName !== desiredBase
+            ) {
+                rowEffects.push({
+                    type: "update-pr",
+                    bookmark: bookmark.name,
+                    prNumber: pull.number,
+                    from: pull.baseRefName,
+                    to: desiredBase,
+                })
+            }
         }
 
         effects.push(...rowEffects)
@@ -231,6 +266,9 @@ function makePlan<TBookmark extends StackBookmarkInput>(
         rebaseBookmarks: uniqueStrings(
             effects.filter((e) => e.type === "rebase").map((e) => e.bookmark),
         ),
+        abandonBookmarks: uniqueStrings(
+            effects.filter((e) => e.type === "abandon").map((e) => e.bookmark),
+        ),
         closePrNumbers: uniqueNumbers(
             effects
                 .filter((e) => e.type === "close-pr" && e.prNumber)
@@ -256,11 +294,27 @@ function submitNote(effects: readonly StackPlanEffect[], desiredBase: string) {
 
 function syncNote(effects: readonly StackPlanEffect[], desiredBase: string) {
     const closePr = effects.find((effect) => effect.type === "close-pr")
-    if (closePr) return closePr.reason ?? "would close descendant PR"
+    if (closePr) {
+        return closePr.reason
+            ? `would close PR: ${closePr.reason}`
+            : "would close descendant PR"
+    }
     const blocked = effects.find((effect) => effect.type === "blocked")
-    if (blocked) return blocked.reason ?? "blocked"
-    if (effects.some((effect) => effect.type === "rebase"))
-        return `would rebase onto ${desiredBase}`
+    if (blocked) {
+        return blocked.reason ? `blocked: ${blocked.reason}` : "blocked"
+    }
+    const abandons = effects.some((effect) => effect.type === "abandon")
+    const rebases = effects.some((effect) => effect.type === "rebase")
+    const pushes = effects.some((effect) => effect.type === "push")
+    const retargets = effects.some((effect) => effect.type === "update-pr")
+    if (abandons) return "would abandon merged local change"
+    if (rebases && retargets && pushes)
+        return `would rebase, push, and retarget onto ${desiredBase}`
+    if (rebases && retargets)
+        return `would rebase and retarget onto ${desiredBase}`
+    if (rebases && pushes) return `would rebase and push onto ${desiredBase}`
+    if (rebases) return `would rebase onto ${desiredBase}`
+    if (retargets) return `would retarget PR onto ${desiredBase}`
     return `targets ${desiredBase}`
 }
 

--- a/src/stack/planner.ts
+++ b/src/stack/planner.ts
@@ -1,0 +1,208 @@
+import { Effect } from "effect"
+import type {
+    BookmarkStackModel,
+    BookmarkStackRow,
+    StackBookmarkInput,
+    StackPlan,
+    StackPlanRow,
+    StackPullRequestInput,
+    StackRemoteBookmarkInput,
+} from "./model"
+
+export interface BuildStackPlanOptions<TBookmark extends StackBookmarkInput> {
+    readonly stackRootName: string
+    readonly stackModel: BookmarkStackModel<TBookmark>
+    readonly pullRequestsByHead: ReadonlyMap<string, StackPullRequestInput>
+    readonly remoteBookmarksByName?: ReadonlyMap<
+        string,
+        StackRemoteBookmarkInput
+    >
+}
+
+export const buildSubmitPlan = Effect.fn("Stack.plan.submit")(
+    <TBookmark extends StackBookmarkInput>(
+        options: BuildStackPlanOptions<TBookmark>,
+    ) => Effect.succeed(buildSubmitPlanSync(options)),
+)
+
+export const buildSyncPlan = Effect.fn("Stack.plan.sync")(
+    <TBookmark extends StackBookmarkInput>(
+        options: BuildStackPlanOptions<TBookmark>,
+    ) => Effect.succeed(buildSyncPlanSync(options)),
+)
+
+export function buildSubmitPlanSync<TBookmark extends StackBookmarkInput>({
+    stackRootName,
+    stackModel,
+    pullRequestsByHead,
+    remoteBookmarksByName = new Map(),
+}: BuildStackPlanOptions<TBookmark>): StackPlan<TBookmark> {
+    const rows = stackRows(stackRootName, stackModel)
+    const planRows: StackPlanRow<TBookmark>[] = []
+    const updatePrNumbers: number[] = []
+    const createPrBookmarks: string[] = []
+    const pushBookmarks: string[] = []
+
+    for (const row of rows) {
+        const bookmark = row.bookmark
+        const desiredBase = desiredLocalBase(bookmark.name, stackModel)
+        const pull = pullRequestsByHead.get(bookmark.name)
+        const remote = remoteBookmarksByName.get(bookmark.name)
+        const isTrunk = stackModel.trunkNames.has(bookmark.name)
+        const needsPush = Boolean(
+            !isTrunk &&
+                bookmark.commitId &&
+                (!remote || remote.commitId !== bookmark.commitId),
+        )
+
+        if (isTrunk) {
+            planRows.push({
+                row,
+                desiredBase,
+                status: "current",
+                note: "",
+            })
+            continue
+        }
+
+        if (!pull) {
+            createPrBookmarks.push(bookmark.name)
+            if (needsPush) pushBookmarks.push(bookmark.name)
+            planRows.push({
+                row,
+                desiredBase,
+                status: "create-pr",
+                note: `would create PR onto ${desiredBase}`,
+            })
+            continue
+        }
+
+        if (pull.baseRefName && pull.baseRefName !== desiredBase) {
+            updatePrNumbers.push(pull.number)
+            if (needsPush) pushBookmarks.push(bookmark.name)
+            planRows.push({
+                row,
+                prNumber: pull.number,
+                desiredBase,
+                status: "update-pr",
+                note: `would retarget PR onto ${desiredBase}`,
+            })
+            continue
+        }
+
+        if (needsPush) {
+            pushBookmarks.push(bookmark.name)
+            planRows.push({
+                row,
+                prNumber: pull.number,
+                desiredBase,
+                status: "push",
+                note: "would push bookmark",
+            })
+            continue
+        }
+
+        planRows.push({
+            row,
+            prNumber: pull.number,
+            desiredBase,
+            status: "current",
+            note: `targets ${desiredBase}`,
+        })
+    }
+
+    return {
+        kind: "submit",
+        stackRootName,
+        rows: planRows,
+        updatePrNumbers: uniqueNumbers(updatePrNumbers),
+        createPrBookmarks: uniqueStrings(createPrBookmarks),
+        pushBookmarks: uniqueStrings(pushBookmarks),
+        rebaseBookmarks: [],
+        applyCommand: "stack submit",
+    }
+}
+
+export function buildSyncPlanSync<TBookmark extends StackBookmarkInput>({
+    stackRootName,
+    stackModel,
+    pullRequestsByHead,
+}: BuildStackPlanOptions<TBookmark>): StackPlan<TBookmark> {
+    const rows = stackRows(stackRootName, stackModel)
+    const planRows: StackPlanRow<TBookmark>[] = []
+    const rebaseBookmarks: string[] = []
+
+    for (const row of rows) {
+        const bookmark = row.bookmark
+        const pull = pullRequestsByHead.get(bookmark.name)
+        const localBase = desiredLocalBase(bookmark.name, stackModel)
+        const desiredBase = pull?.baseRefName ?? localBase
+        const isTrunk = stackModel.trunkNames.has(bookmark.name)
+
+        if (isTrunk) {
+            planRows.push({
+                row,
+                prNumber: pull?.number,
+                desiredBase,
+                status: "current",
+                note: "",
+            })
+            continue
+        }
+
+        if (desiredBase !== localBase) {
+            rebaseBookmarks.push(bookmark.name)
+            planRows.push({
+                row,
+                prNumber: pull?.number,
+                desiredBase,
+                status: "rebase",
+                note: `would rebase onto ${desiredBase}`,
+            })
+            continue
+        }
+
+        planRows.push({
+            row,
+            prNumber: pull?.number,
+            desiredBase,
+            status: "current",
+            note: `targets ${desiredBase}`,
+        })
+    }
+
+    return {
+        kind: "sync",
+        stackRootName,
+        rows: planRows,
+        updatePrNumbers: [],
+        createPrBookmarks: [],
+        pushBookmarks: [],
+        rebaseBookmarks: uniqueStrings(rebaseBookmarks),
+        applyCommand: "stack sync",
+    }
+}
+
+function stackRows<TBookmark extends StackBookmarkInput>(
+    stackRootName: string,
+    stackModel: BookmarkStackModel<TBookmark>,
+): readonly BookmarkStackRow<TBookmark>[] {
+    const rows = stackModel.rows.filter((row) =>
+        row.stackKeys.includes(stackRootName),
+    )
+    const minDepth = Math.min(...rows.map((row) => row.depth))
+    return rows.map((row) => ({
+        ...row,
+        depth: Math.max(0, row.depth - minDepth),
+    }))
+}
+
+function desiredLocalBase<TBookmark extends StackBookmarkInput>(
+    bookmarkName: string,
+    stackModel: BookmarkStackModel<TBookmark>,
+): string {
+    return stackModel.parentByName.get(bookmarkName) ?? bookmarkName
+}
+
+const uniqueStrings = (values: readonly string[]) => [...new Set(values)]
+const uniqueNumbers = (values: readonly number[]) => [...new Set(values)]

--- a/src/stack/planner.ts
+++ b/src/stack/planner.ts
@@ -4,6 +4,7 @@ import type {
     BookmarkStackRow,
     StackBookmarkInput,
     StackPlan,
+    StackPlanEffect,
     StackPlanRow,
     StackPullRequestInput,
     StackRemoteBookmarkInput,
@@ -39,9 +40,7 @@ export function buildSubmitPlanSync<TBookmark extends StackBookmarkInput>({
 }: BuildStackPlanOptions<TBookmark>): StackPlan<TBookmark> {
     const rows = stackRows(stackRootName, stackModel)
     const planRows: StackPlanRow<TBookmark>[] = []
-    const updatePrNumbers: number[] = []
-    const createPrBookmarks: string[] = []
-    const pushBookmarks: string[] = []
+    const effects: StackPlanEffect[] = []
 
     for (const row of rows) {
         const bookmark = row.bookmark
@@ -49,6 +48,7 @@ export function buildSubmitPlanSync<TBookmark extends StackBookmarkInput>({
         const pull = pullRequestsByHead.get(bookmark.name)
         const remote = remoteBookmarksByName.get(bookmark.name)
         const isTrunk = stackModel.trunkNames.has(bookmark.name)
+        const rowEffects: StackPlanEffect[] = []
         const needsPush = Boolean(
             !isTrunk &&
                 bookmark.commitId &&
@@ -56,71 +56,50 @@ export function buildSubmitPlanSync<TBookmark extends StackBookmarkInput>({
         )
 
         if (isTrunk) {
-            planRows.push({
-                row,
-                desiredBase,
-                status: "current",
-                note: "",
-            })
-            continue
-        }
-
-        if (!pull) {
-            createPrBookmarks.push(bookmark.name)
-            if (needsPush) pushBookmarks.push(bookmark.name)
-            planRows.push({
-                row,
-                desiredBase,
-                status: "create-pr",
-                note: `would create PR onto ${desiredBase}`,
-            })
-            continue
-        }
-
-        if (pull.baseRefName && pull.baseRefName !== desiredBase) {
-            updatePrNumbers.push(pull.number)
-            if (needsPush) pushBookmarks.push(bookmark.name)
-            planRows.push({
-                row,
-                prNumber: pull.number,
-                desiredBase,
-                status: "update-pr",
-                note: `would retarget PR onto ${desiredBase}`,
-            })
+            planRows.push(rowPlan(row, pull, desiredBase, rowEffects, ""))
             continue
         }
 
         if (needsPush) {
-            pushBookmarks.push(bookmark.name)
-            planRows.push({
-                row,
-                prNumber: pull.number,
-                desiredBase,
-                status: "push",
-                note: "would push bookmark",
-            })
-            continue
+            rowEffects.push({ type: "push", bookmark: bookmark.name })
         }
 
-        planRows.push({
-            row,
-            prNumber: pull.number,
-            desiredBase,
-            status: "current",
-            note: `targets ${desiredBase}`,
-        })
+        if (!pull) {
+            rowEffects.push({
+                type: "create-pr",
+                bookmark: bookmark.name,
+                to: desiredBase,
+            })
+        } else {
+            if (pull.baseRefName && pull.baseRefName !== desiredBase) {
+                rowEffects.push({
+                    type: "update-pr",
+                    bookmark: bookmark.name,
+                    prNumber: pull.number,
+                    from: pull.baseRefName,
+                    to: desiredBase,
+                })
+            }
+            rowEffects.push({
+                type: "update-comment",
+                bookmark: bookmark.name,
+                prNumber: pull.number,
+            })
+        }
+
+        effects.push(...rowEffects)
+        planRows.push(
+            rowPlan(
+                row,
+                pull,
+                desiredBase,
+                rowEffects,
+                submitNote(rowEffects, desiredBase),
+            ),
+        )
     }
 
-    return {
-        kind: "submit",
-        stackRootName,
-        rows: planRows,
-        updatePrNumbers: uniqueNumbers(updatePrNumbers),
-        createPrBookmarks: uniqueStrings(createPrBookmarks),
-        pushBookmarks: uniqueStrings(pushBookmarks),
-        rebaseBookmarks: [],
-        applyCommand: "stack submit",
-    }
+    return makePlan("submit", stackRootName, planRows, effects, "stack submit")
 }
 
 export function buildSyncPlanSync<TBookmark extends StackBookmarkInput>({
@@ -130,7 +109,8 @@ export function buildSyncPlanSync<TBookmark extends StackBookmarkInput>({
 }: BuildStackPlanOptions<TBookmark>): StackPlan<TBookmark> {
     const rows = stackRows(stackRootName, stackModel)
     const planRows: StackPlanRow<TBookmark>[] = []
-    const rebaseBookmarks: string[] = []
+    const effects: StackPlanEffect[] = []
+    let blockedByClosedUnmerged: StackPullRequestInput | undefined
 
     for (const row of rows) {
         const bookmark = row.bookmark
@@ -138,49 +118,150 @@ export function buildSyncPlanSync<TBookmark extends StackBookmarkInput>({
         const localBase = desiredLocalBase(bookmark.name, stackModel)
         const desiredBase = pull?.baseRefName ?? localBase
         const isTrunk = stackModel.trunkNames.has(bookmark.name)
+        const rowEffects: StackPlanEffect[] = []
 
         if (isTrunk) {
-            planRows.push({
-                row,
-                prNumber: pull?.number,
-                desiredBase,
-                status: "current",
-                note: "",
-            })
+            planRows.push(rowPlan(row, pull, desiredBase, rowEffects, ""))
             continue
         }
 
-        if (desiredBase !== localBase) {
-            rebaseBookmarks.push(bookmark.name)
-            planRows.push({
-                row,
-                prNumber: pull?.number,
-                desiredBase,
-                status: "rebase",
-                note: `would rebase onto ${desiredBase}`,
-            })
+        if (blockedByClosedUnmerged) {
+            if (pull?.number && pull.state === "OPEN") {
+                rowEffects.push({
+                    type: "close-pr",
+                    bookmark: bookmark.name,
+                    prNumber: pull.number,
+                    reason: `parent #${blockedByClosedUnmerged.number} was closed without merging`,
+                })
+            } else {
+                rowEffects.push({
+                    type: "blocked",
+                    bookmark: bookmark.name,
+                    reason: `parent #${blockedByClosedUnmerged.number} was closed without merging`,
+                })
+            }
+            effects.push(...rowEffects)
+            planRows.push(
+                rowPlan(
+                    row,
+                    pull,
+                    desiredBase,
+                    rowEffects,
+                    syncNote(rowEffects, desiredBase),
+                ),
+            )
             continue
         }
 
-        planRows.push({
-            row,
-            prNumber: pull?.number,
-            desiredBase,
-            status: "current",
-            note: `targets ${desiredBase}`,
-        })
+        if (pull?.state === "CLOSED" && pull.merged === false) {
+            blockedByClosedUnmerged = pull
+            rowEffects.push({
+                type: "blocked",
+                bookmark: bookmark.name,
+                prNumber: pull.number,
+                reason: "PR was closed without merging",
+            })
+        } else if (desiredBase !== localBase) {
+            rowEffects.push({
+                type: "rebase",
+                bookmark: bookmark.name,
+                prNumber: pull?.number,
+                from: localBase,
+                to: desiredBase,
+            })
+        }
+
+        effects.push(...rowEffects)
+        planRows.push(
+            rowPlan(
+                row,
+                pull,
+                desiredBase,
+                rowEffects,
+                syncNote(rowEffects, desiredBase),
+            ),
+        )
     }
 
+    return makePlan("sync", stackRootName, planRows, effects, "stack sync")
+}
+
+function rowPlan<TBookmark extends StackBookmarkInput>(
+    row: BookmarkStackRow<TBookmark>,
+    pull: StackPullRequestInput | undefined,
+    desiredBase: string,
+    effects: readonly StackPlanEffect[],
+    fallbackNote: string,
+): StackPlanRow<TBookmark> {
     return {
-        kind: "sync",
-        stackRootName,
-        rows: planRows,
-        updatePrNumbers: [],
-        createPrBookmarks: [],
-        pushBookmarks: [],
-        rebaseBookmarks: uniqueStrings(rebaseBookmarks),
-        applyCommand: "stack sync",
+        row,
+        prNumber: pull?.number,
+        desiredBase,
+        status: effects[0]?.type ?? "current",
+        note: fallbackNote,
+        effects,
     }
+}
+
+function makePlan<TBookmark extends StackBookmarkInput>(
+    kind: "submit" | "sync",
+    stackRootName: string,
+    rows: readonly StackPlanRow<TBookmark>[],
+    effects: readonly StackPlanEffect[],
+    applyCommand: string,
+): StackPlan<TBookmark> {
+    return {
+        kind,
+        stackRootName,
+        rows,
+        effects,
+        updatePrNumbers: uniqueNumbers(
+            effects
+                .filter((e) => e.type === "update-pr" && e.prNumber)
+                .map((e) => e.prNumber ?? 0),
+        ),
+        createPrBookmarks: uniqueStrings(
+            effects
+                .filter((e) => e.type === "create-pr")
+                .map((e) => e.bookmark),
+        ),
+        pushBookmarks: uniqueStrings(
+            effects.filter((e) => e.type === "push").map((e) => e.bookmark),
+        ),
+        rebaseBookmarks: uniqueStrings(
+            effects.filter((e) => e.type === "rebase").map((e) => e.bookmark),
+        ),
+        closePrNumbers: uniqueNumbers(
+            effects
+                .filter((e) => e.type === "close-pr" && e.prNumber)
+                .map((e) => e.prNumber ?? 0),
+        ),
+        applyCommand,
+    }
+}
+
+function submitNote(effects: readonly StackPlanEffect[], desiredBase: string) {
+    if (effects.some((effect) => effect.type === "create-pr")) {
+        return `would create PR onto ${desiredBase}`
+    }
+    if (effects.some((effect) => effect.type === "update-pr")) {
+        return `would retarget PR onto ${desiredBase}`
+    }
+    if (effects.some((effect) => effect.type === "push"))
+        return "would push bookmark"
+    if (effects.some((effect) => effect.type === "update-comment"))
+        return "would update stack comment"
+    return `targets ${desiredBase}`
+}
+
+function syncNote(effects: readonly StackPlanEffect[], desiredBase: string) {
+    const closePr = effects.find((effect) => effect.type === "close-pr")
+    if (closePr) return closePr.reason ?? "would close descendant PR"
+    const blocked = effects.find((effect) => effect.type === "blocked")
+    if (blocked) return blocked.reason ?? "blocked"
+    if (effects.some((effect) => effect.type === "rebase"))
+        return `would rebase onto ${desiredBase}`
+    return `targets ${desiredBase}`
 }
 
 function stackRows<TBookmark extends StackBookmarkInput>(

--- a/src/stack/planner.ts
+++ b/src/stack/planner.ts
@@ -175,7 +175,7 @@ export function buildSyncPlanSync<TBookmark extends StackBookmarkInput>({
                     bookmark: bookmark.name,
                     prNumber: pull.number,
                     reason: "PR was merged",
-                    revision: bookmark.changeId ?? bookmark.name,
+                    revision: `${desiredBase}..${bookmark.changeId ?? bookmark.name}`,
                 })
             }
             if (desiredBase !== localBase) {

--- a/src/stack/state.ts
+++ b/src/stack/state.ts
@@ -1,0 +1,66 @@
+import { dirname, resolve } from "node:path"
+import { getRepoPath } from "../repo"
+
+export interface PersistedStackEntry {
+    readonly bookmark: string
+    readonly parent: string
+    readonly prNumber?: number
+    readonly headChangeId?: string
+    readonly headCommitId?: string
+    readonly parentChangeId?: string
+    readonly parentCommitId?: string
+    readonly baseRefName?: string
+    readonly syncedAt: string
+}
+
+export interface PersistedStackState {
+    readonly version: 1
+    readonly entries: readonly PersistedStackEntry[]
+}
+
+const emptyState = (): PersistedStackState => ({ version: 1, entries: [] })
+
+export async function stackStatePath(): Promise<string> {
+    const root = getRepoPath()
+    const jjRepoFile = `${root}/.jj/repo`
+    let repoPath = jjRepoFile
+    try {
+        const stat = await import("node:fs/promises").then((fs) =>
+            fs.stat(jjRepoFile),
+        )
+        if (stat.isFile()) {
+            const pointer = (await Bun.file(jjRepoFile).text()).trim()
+            repoPath = resolve(dirname(jjRepoFile), pointer)
+        }
+    } catch {
+        repoPath = `${root}/.jj/repo`
+    }
+    return `${repoPath}/kajji/stack-state.json`
+}
+
+export async function readPersistedStackState(): Promise<PersistedStackState> {
+    try {
+        const path = await stackStatePath()
+        const raw = await Bun.file(path).text()
+        const parsed = JSON.parse(raw) as Partial<PersistedStackState>
+        if (parsed.version !== 1 || !Array.isArray(parsed.entries))
+            return emptyState()
+        return { version: 1, entries: parsed.entries }
+    } catch {
+        return emptyState()
+    }
+}
+
+export async function writePersistedStackState(
+    state: PersistedStackState,
+): Promise<void> {
+    const path = await stackStatePath()
+    await import("node:fs/promises").then((fs) =>
+        fs.mkdir(dirname(path), { recursive: true }),
+    )
+    await Bun.write(path, `${JSON.stringify(state, null, 2)}\n`)
+}
+
+export function entriesByBookmark(state: PersistedStackState) {
+    return new Map(state.entries.map((entry) => [entry.bookmark, entry]))
+}

--- a/tests/unit/commander/github.test.ts
+++ b/tests/unit/commander/github.test.ts
@@ -84,7 +84,7 @@ describe("parseGhPullRequestsByHeadGraphqlJson", () => {
         expect([...pulls.values()]).toEqual([])
     })
 
-    test("prefers open PRs over older closed PRs for the same head", () => {
+    test("prefers latest PR for the same head", () => {
         const pulls = parseGhPullRequestsByHeadGraphqlJsonIncludingClosed(
             JSON.stringify({
                 data: {
@@ -119,7 +119,7 @@ describe("parseGhPullRequestsByHeadGraphqlJson", () => {
         expect(pulls.get("feature-a")?.number).toBe(110)
     })
 
-    test("prefers merged closed PR over newer unmerged closed PR", () => {
+    test("prefers newer unmerged closed PR over older merged PR", () => {
         const pulls = parseGhPullRequestsByHeadGraphqlJsonIncludingClosed(
             JSON.stringify({
                 data: {
@@ -149,10 +149,10 @@ describe("parseGhPullRequestsByHeadGraphqlJson", () => {
             }),
         )
 
-        expect(pulls.get("feature-a")?.number).toBe(114)
+        expect(pulls.get("feature-a")?.number).toBe(112)
     })
 
-    test("prefers newest closed PR when no open or merged PR exists for the same head", () => {
+    test("prefers newest closed PR for the same head", () => {
         const pulls = parseGhPullRequestsByHeadGraphqlJsonIncludingClosed(
             JSON.stringify({
                 data: {
@@ -214,6 +214,39 @@ describe("parseGhPullRequestsByHeadGraphqlJson", () => {
             baseRefName: "main",
             state: "CLOSED",
             merged: false,
+        })
+    })
+
+    test("finds PRs by head name when the branch ref was deleted", () => {
+        const pulls = parseGhPullRequestsByHeadGraphqlJsonIncludingClosed(
+            JSON.stringify({
+                data: {
+                    repository: {
+                        h0: null,
+                        p0: {
+                            nodes: [
+                                {
+                                    number: 120,
+                                    headRefName: "feature-a",
+                                    baseRefName: "main",
+                                    state: "MERGED",
+                                    merged: true,
+                                    updatedAt: "2026-01-02T00:00:00Z",
+                                },
+                            ],
+                        },
+                    },
+                },
+            }),
+        )
+
+        expect(pulls.get("feature-a")).toEqual({
+            number: 120,
+            headRefName: "feature-a",
+            baseRefName: "main",
+            state: "MERGED",
+            merged: true,
+            updatedAt: "2026-01-02T00:00:00Z",
         })
     })
 

--- a/tests/unit/commander/github.test.ts
+++ b/tests/unit/commander/github.test.ts
@@ -23,7 +23,11 @@ describe("parseGhPullRequestsByHeadGraphqlJson", () => {
                         h0: {
                             associatedPullRequests: {
                                 nodes: [
-                                    { number: 123, headRefName: "feature-a" },
+                                    {
+                                        number: 123,
+                                        headRefName: "feature-a",
+                                        baseRefName: "main",
+                                    },
                                 ],
                             },
                         },
@@ -40,7 +44,10 @@ describe("parseGhPullRequestsByHeadGraphqlJson", () => {
         )
 
         expect([...pulls.entries()]).toEqual([
-            ["feature-a", { number: 123, headRefName: "feature-a" }],
+            [
+                "feature-a",
+                { number: 123, headRefName: "feature-a", baseRefName: "main" },
+            ],
             ["feature-b", { number: 124, headRefName: "feature-b" }],
         ])
     })

--- a/tests/unit/commander/github.test.ts
+++ b/tests/unit/commander/github.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test"
+import {
+    parseGhPullRequestsByHeadGraphqlJson,
+    parseGhRepositoryJson,
+} from "../../../src/commander/github"
+
+describe("parseGhRepositoryJson", () => {
+    test("parses owner and repo name", () => {
+        expect(
+            parseGhRepositoryJson(
+                JSON.stringify({ owner: { login: "eliaskc" }, name: "kajji" }),
+            ),
+        ).toEqual({ owner: "eliaskc", name: "kajji" })
+    })
+})
+
+describe("parseGhPullRequestsByHeadGraphqlJson", () => {
+    test("parses PR number by head ref from aliased refs", () => {
+        const pulls = parseGhPullRequestsByHeadGraphqlJson(
+            JSON.stringify({
+                data: {
+                    repository: {
+                        h0: {
+                            associatedPullRequests: {
+                                nodes: [
+                                    { number: 123, headRefName: "feature-a" },
+                                ],
+                            },
+                        },
+                        h1: {
+                            associatedPullRequests: {
+                                nodes: [
+                                    { number: 124, headRefName: "feature-b" },
+                                ],
+                            },
+                        },
+                    },
+                },
+            }),
+        )
+
+        expect([...pulls.entries()]).toEqual([
+            ["feature-a", { number: 123, headRefName: "feature-a" }],
+            ["feature-b", { number: 124, headRefName: "feature-b" }],
+        ])
+    })
+
+    test("skips missing refs and malformed entries", () => {
+        const pulls = parseGhPullRequestsByHeadGraphqlJson(
+            JSON.stringify({
+                data: {
+                    repository: {
+                        h0: null,
+                        h1: {
+                            associatedPullRequests: {
+                                nodes: [
+                                    { number: 123, headRefName: "feature-a" },
+                                    { number: "bad", headRefName: "feature-b" },
+                                    { number: 124 },
+                                    null,
+                                ],
+                            },
+                        },
+                    },
+                },
+            }),
+        )
+
+        expect([...pulls.values()]).toEqual([
+            { number: 123, headRefName: "feature-a" },
+        ])
+    })
+})

--- a/tests/unit/commander/github.test.ts
+++ b/tests/unit/commander/github.test.ts
@@ -84,6 +84,107 @@ describe("parseGhPullRequestsByHeadGraphqlJson", () => {
         expect([...pulls.values()]).toEqual([])
     })
 
+    test("prefers open PRs over older closed PRs for the same head", () => {
+        const pulls = parseGhPullRequestsByHeadGraphqlJsonIncludingClosed(
+            JSON.stringify({
+                data: {
+                    repository: {
+                        h0: {
+                            associatedPullRequests: {
+                                nodes: [
+                                    {
+                                        number: 100,
+                                        headRefName: "feature-a",
+                                        baseRefName: "main",
+                                        state: "CLOSED",
+                                        merged: false,
+                                        updatedAt: "2026-01-01T00:00:00Z",
+                                    },
+                                    {
+                                        number: 110,
+                                        headRefName: "feature-a",
+                                        baseRefName: "main",
+                                        state: "OPEN",
+                                        merged: false,
+                                        updatedAt: "2026-01-02T00:00:00Z",
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                },
+            }),
+        )
+
+        expect(pulls.get("feature-a")?.number).toBe(110)
+    })
+
+    test("prefers merged closed PR over newer unmerged closed PR", () => {
+        const pulls = parseGhPullRequestsByHeadGraphqlJsonIncludingClosed(
+            JSON.stringify({
+                data: {
+                    repository: {
+                        h0: {
+                            associatedPullRequests: {
+                                nodes: [
+                                    {
+                                        number: 112,
+                                        headRefName: "feature-a",
+                                        state: "CLOSED",
+                                        merged: false,
+                                        updatedAt: "2026-01-03T00:00:00Z",
+                                    },
+                                    {
+                                        number: 114,
+                                        headRefName: "feature-a",
+                                        state: "MERGED",
+                                        merged: true,
+                                        updatedAt: "2026-01-02T00:00:00Z",
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                },
+            }),
+        )
+
+        expect(pulls.get("feature-a")?.number).toBe(114)
+    })
+
+    test("prefers newest closed PR when no open or merged PR exists for the same head", () => {
+        const pulls = parseGhPullRequestsByHeadGraphqlJsonIncludingClosed(
+            JSON.stringify({
+                data: {
+                    repository: {
+                        h0: {
+                            associatedPullRequests: {
+                                nodes: [
+                                    {
+                                        number: 100,
+                                        headRefName: "feature-a",
+                                        state: "CLOSED",
+                                        merged: false,
+                                        updatedAt: "2026-01-01T00:00:00Z",
+                                    },
+                                    {
+                                        number: 110,
+                                        headRefName: "feature-a",
+                                        state: "CLOSED",
+                                        merged: false,
+                                        updatedAt: "2026-01-02T00:00:00Z",
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                },
+            }),
+        )
+
+        expect(pulls.get("feature-a")?.number).toBe(110)
+    })
+
     test("can include closed PRs with merged state for sync planning", () => {
         const pulls = parseGhPullRequestsByHeadGraphqlJsonIncludingClosed(
             JSON.stringify({

--- a/tests/unit/commander/github.test.ts
+++ b/tests/unit/commander/github.test.ts
@@ -3,6 +3,7 @@ import {
     parseGhPullRequestsByHeadGraphqlJson,
     parseGhPullRequestsByHeadGraphqlJsonIncludingClosed,
     parseGhRepositoryJson,
+    parseGitHubRemoteUrl,
 } from "../../../src/commander/github"
 
 describe("parseGhRepositoryJson", () => {
@@ -12,6 +13,26 @@ describe("parseGhRepositoryJson", () => {
                 JSON.stringify({ owner: { login: "eliaskc" }, name: "kajji" }),
             ),
         ).toEqual({ owner: "eliaskc", name: "kajji" })
+    })
+})
+
+describe("parseGitHubRemoteUrl", () => {
+    test("parses ssh and https GitHub remotes", () => {
+        expect(
+            parseGitHubRemoteUrl("git@github.com:MDLabs/apnea-sdk-ios"),
+        ).toEqual({
+            owner: "MDLabs",
+            name: "apnea-sdk-ios",
+        })
+        expect(
+            parseGitHubRemoteUrl("https://github.com/eliaskc/kajji.git"),
+        ).toEqual({ owner: "eliaskc", name: "kajji" })
+    })
+
+    test("ignores non-GitHub remotes", () => {
+        expect(
+            parseGitHubRemoteUrl("git@example.com:owner/repo.git"),
+        ).toBeUndefined()
     })
 })
 

--- a/tests/unit/commander/github.test.ts
+++ b/tests/unit/commander/github.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import {
     parseGhPullRequestsByHeadGraphqlJson,
+    parseGhPullRequestsByHeadGraphqlJsonIncludingClosed,
     parseGhRepositoryJson,
 } from "../../../src/commander/github"
 
@@ -81,6 +82,38 @@ describe("parseGhPullRequestsByHeadGraphqlJson", () => {
         )
 
         expect([...pulls.values()]).toEqual([])
+    })
+
+    test("can include closed PRs with merged state for sync planning", () => {
+        const pulls = parseGhPullRequestsByHeadGraphqlJsonIncludingClosed(
+            JSON.stringify({
+                data: {
+                    repository: {
+                        h0: {
+                            associatedPullRequests: {
+                                nodes: [
+                                    {
+                                        number: 123,
+                                        headRefName: "feature-a",
+                                        baseRefName: "main",
+                                        state: "CLOSED",
+                                        merged: false,
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                },
+            }),
+        )
+
+        expect(pulls.get("feature-a")).toEqual({
+            number: 123,
+            headRefName: "feature-a",
+            baseRefName: "main",
+            state: "CLOSED",
+            merged: false,
+        })
     })
 
     test("skips missing refs and malformed entries", () => {

--- a/tests/unit/commander/github.test.ts
+++ b/tests/unit/commander/github.test.ts
@@ -27,6 +27,7 @@ describe("parseGhPullRequestsByHeadGraphqlJson", () => {
                                         number: 123,
                                         headRefName: "feature-a",
                                         baseRefName: "main",
+                                        state: "OPEN",
                                     },
                                 ],
                             },
@@ -46,10 +47,40 @@ describe("parseGhPullRequestsByHeadGraphqlJson", () => {
         expect([...pulls.entries()]).toEqual([
             [
                 "feature-a",
-                { number: 123, headRefName: "feature-a", baseRefName: "main" },
+                {
+                    number: 123,
+                    headRefName: "feature-a",
+                    baseRefName: "main",
+                    state: "OPEN",
+                },
             ],
             ["feature-b", { number: 124, headRefName: "feature-b" }],
         ])
+    })
+
+    test("skips closed PRs defensively", () => {
+        const pulls = parseGhPullRequestsByHeadGraphqlJson(
+            JSON.stringify({
+                data: {
+                    repository: {
+                        h0: {
+                            associatedPullRequests: {
+                                nodes: [
+                                    {
+                                        number: 123,
+                                        headRefName: "feature-a",
+                                        baseRefName: "main",
+                                        state: "CLOSED",
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                },
+            }),
+        )
+
+        expect([...pulls.values()]).toEqual([])
     })
 
     test("skips missing refs and malformed entries", () => {

--- a/tests/unit/stack/discovery.test.ts
+++ b/tests/unit/stack/discovery.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import { buildBookmarkStackModel } from "../../../src/stack/discovery"
+
+const commits = [
+    { commitId: "main", parentCommitIds: [], immutable: true },
+    { commitId: "a", parentCommitIds: ["main"], immutable: false },
+    { commitId: "b", parentCommitIds: ["a"], immutable: false },
+    { commitId: "c", parentCommitIds: ["b"], immutable: false },
+    { commitId: "solo", parentCommitIds: ["main"], immutable: false },
+]
+
+const bookmarks = [
+    { name: "main", commitId: "main", changeId: "main" },
+    { name: "feature-a", commitId: "a", changeId: "a" },
+    { name: "feature-b", commitId: "b", changeId: "b" },
+    { name: "feature-c", commitId: "c", changeId: "c" },
+    { name: "standalone", commitId: "solo", changeId: "solo" },
+]
+
+describe("buildBookmarkStackModel", () => {
+    test("renders only actual multi-bookmark stacks under trunk", async () => {
+        const model = await Effect.runPromise(
+            buildBookmarkStackModel({ commits, bookmarks }),
+        )
+
+        expect(model.rows.map((row) => [row.bookmark.name, row.depth])).toEqual(
+            [
+                ["main", 0],
+                ["feature-a", 1],
+                ["feature-b", 2],
+                ["feature-c", 3],
+                ["standalone", 0],
+            ],
+        )
+        expect(model.parentByName.get("feature-a")).toBe("main")
+        expect(model.parentByName.get("feature-b")).toBe("feature-a")
+        expect(model.parentByName.get("feature-c")).toBe("feature-b")
+        expect(model.parentByName.has("standalone")).toBe(false)
+    })
+
+    test("marks all stack members with the stack root key for highlighting", async () => {
+        const model = await Effect.runPromise(
+            buildBookmarkStackModel({ commits, bookmarks }),
+        )
+        const stackKeysByName = new Map(
+            model.rows.map((row) => [row.bookmark.name, row.stackKeys]),
+        )
+
+        expect(stackKeysByName.get("main")).toEqual(["feature-a"])
+        expect(stackKeysByName.get("feature-a")).toEqual(["feature-a"])
+        expect(stackKeysByName.get("feature-b")).toEqual(["feature-a"])
+        expect(stackKeysByName.get("feature-c")).toEqual(["feature-a"])
+        expect(stackKeysByName.get("standalone")).toEqual([])
+    })
+
+    test("does not stack when every bookmark targets trunk", async () => {
+        const model = await Effect.runPromise(
+            buildBookmarkStackModel({
+                commits,
+                bookmarks: [
+                    { name: "main", commitId: "main", changeId: "main" },
+                    { name: "one", commitId: "a", changeId: "a" },
+                    { name: "two", commitId: "solo", changeId: "solo" },
+                ],
+            }),
+        )
+
+        expect(model.rows.map((row) => [row.bookmark.name, row.depth])).toEqual(
+            [
+                ["main", 0],
+                ["one", 0],
+                ["two", 0],
+            ],
+        )
+    })
+})

--- a/tests/unit/stack/executor.test.ts
+++ b/tests/unit/stack/executor.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, mock, test } from "bun:test"
+import { Effect } from "effect"
+import type { Bookmark } from "../../../src/commander/bookmarks"
+import type { GitHubPullRequestSummary } from "../../../src/commander/github"
+import type { Commit } from "../../../src/commander/types"
+import type { StackPlan } from "../../../src/stack/model"
+
+const calls: string[] = []
+let fetchLogCalls = 0
+let fetchBookmarkCalls = 0
+
+const mainCommit = commit("main-commit", [], true)
+const parentCommit = commit("parent-commit", ["main-commit"])
+const childCommit = commit("child-commit", ["parent-commit"])
+
+const mainBookmark = bookmark("main", "main-commit", "main-change")
+const parentBookmark = bookmark("test/stack", "parent-commit", "parent-change")
+const childBookmark = bookmark("test/stack-2", "child-commit", "child-change")
+
+mock.module("../../../src/commander/log", () => ({
+    fetchLogPage: mock(async () => {
+        fetchLogCalls++
+        return {
+            commits: [childCommit, parentCommit, mainCommit],
+            hasMore: false,
+        }
+    }),
+}))
+
+mock.module("../../../src/commander/bookmarks", () => ({
+    fetchBookmarks: mock(async () => {
+        fetchBookmarkCalls++
+        return fetchBookmarkCalls === 1
+            ? [mainBookmark, parentBookmark, childBookmark]
+            : [mainBookmark, childBookmark]
+    }),
+}))
+
+mock.module("../../../src/commander/github", () => ({
+    ghListPullRequestsByHead: mock(
+        async (
+            heads: readonly string[],
+        ): Promise<Map<string, GitHubPullRequestSummary>> => {
+            expect(heads).toContain("test/stack")
+            return new Map([
+                [
+                    "test/stack",
+                    {
+                        number: 114,
+                        headRefName: "test/stack",
+                        baseRefName: "main",
+                        state: "MERGED",
+                        merged: true,
+                    },
+                ],
+                [
+                    "test/stack-2",
+                    {
+                        number: 117,
+                        headRefName: "test/stack-2",
+                        baseRefName: "test/stack",
+                        state: "OPEN",
+                        merged: false,
+                    },
+                ],
+            ])
+        },
+    ),
+    ghPrClose: mock(async () => result("gh pr close")),
+    ghPrCreate: mock(async () => ({ ...result("gh pr create"), prNumber: 1 })),
+    ghPrEditBase: mock(async (prNumber: number, base: string) => {
+        calls.push(`edit:${prNumber}:${base}`)
+        return result("gh pr edit")
+    }),
+    ghPrViewWeb: mock(async () => result("gh pr view")),
+    ghUpsertStackComment: mock(async () => result("gh api")),
+}))
+
+mock.module("../../../src/commander/operations", () => ({
+    fetchOpLogId: mock(async () => "op"),
+    jjGitFetch: mock(async () => result("jj git fetch")),
+    jjGitPushBookmark: mock(async (name: string) => {
+        calls.push(`push:${name}`)
+        return result("jj git push")
+    }),
+    jjRebase: mock(async (name: string, destination: string) => {
+        calls.push(`rebase:${name}:${destination}`)
+        return result("jj rebase")
+    }),
+    jjAbandon: mock(async (revision: string) => {
+        calls.push(`abandon:${revision}`)
+        return result("jj abandon")
+    }),
+}))
+
+mock.module("../../../src/stack/services/StackJournal", () => ({
+    writeStackJournal: mock(async () => undefined),
+}))
+
+describe("stack executor", () => {
+    test("sync preserves selected stack when fetch deleted the merged root bookmark", async () => {
+        fetchLogCalls = 0
+        fetchBookmarkCalls = 0
+
+        const { prepareSyncPlan } = await import("../../../src/stack/executor")
+        const plan = await Effect.runPromise(
+            prepareSyncPlan({ stackRootName: "test/stack" }),
+        )
+
+        expect(fetchLogCalls).toBe(2)
+        expect(plan.rows.map((row) => row.row.bookmark.name)).toEqual([
+            "main",
+            "test/stack",
+            "test/stack-2",
+        ])
+        expect(plan.abandonBookmarks).toEqual(["test/stack"])
+        expect(plan.rebaseBookmarks).toEqual(["test/stack-2"])
+        expect(plan.pushBookmarks).toEqual(["test/stack-2"])
+        expect(plan.updatePrNumbers).toEqual([117])
+        expect(
+            plan.effects.find((effect) => effect.type === "abandon")?.revision,
+        ).toBe("parent-change")
+    })
+
+    test("sync apply abandons merged roots before rebasing and pushing descendants", async () => {
+        calls.length = 0
+        const plan: StackPlan<Bookmark> = {
+            kind: "sync",
+            stackRootName: "test/stack",
+            rows: [],
+            effects: [
+                {
+                    type: "rebase",
+                    bookmark: "test/stack-2",
+                    from: "test/stack",
+                    to: "main",
+                },
+                { type: "push", bookmark: "test/stack-2" },
+                {
+                    type: "update-pr",
+                    bookmark: "test/stack-2",
+                    prNumber: 117,
+                    from: "test/stack",
+                    to: "main",
+                },
+                {
+                    type: "abandon",
+                    bookmark: "test/stack",
+                    prNumber: 114,
+                    revision: "parent-change",
+                },
+            ],
+            updatePrNumbers: [117],
+            createPrBookmarks: [],
+            pushBookmarks: ["test/stack-2"],
+            rebaseBookmarks: ["test/stack-2"],
+            abandonBookmarks: ["test/stack"],
+            closePrNumbers: [],
+            applyCommand: "stack sync",
+        }
+
+        const { applyStackPlan } = await import("../../../src/stack/executor")
+        await Effect.runPromise(applyStackPlan(plan))
+
+        expect(calls).toEqual([
+            "abandon:parent-change",
+            "rebase:test/stack-2:main",
+            "push:test/stack-2",
+            "edit:117:main",
+        ])
+    })
+})
+
+function commit(
+    commitId: string,
+    parentCommitIds: readonly string[],
+    immutable = false,
+): Commit {
+    return {
+        changeId: `${commitId}-change`,
+        commitId,
+        parentCommitIds: [...parentCommitIds],
+        description: commitId,
+        author: "Test",
+        authorEmail: "test@example.com",
+        timestamp: "2026-01-01T00:00:00Z",
+        lines: [],
+        refLine: "",
+        isWorkingCopy: false,
+        immutable,
+        empty: false,
+        divergent: false,
+        bookmarks: [],
+        gitHead: false,
+        workingCopies: [],
+    }
+}
+
+function bookmark(name: string, commitId: string, changeId: string): Bookmark {
+    return {
+        name,
+        nameDisplay: name,
+        changeId,
+        commitId,
+        changeIdDisplay: changeId.slice(0, 8),
+        commitIdDisplay: commitId.slice(0, 8),
+        descriptionDisplay: name,
+        description: name,
+        isLocal: true,
+    }
+}
+
+function result(command: string) {
+    return { command, stdout: "", stderr: "", exitCode: 0, success: true }
+}

--- a/tests/unit/stack/executor.test.ts
+++ b/tests/unit/stack/executor.test.ts
@@ -119,7 +119,7 @@ describe("stack executor", () => {
         expect(plan.updatePrNumbers).toEqual([117])
         expect(
             plan.effects.find((effect) => effect.type === "abandon")?.revision,
-        ).toBe("parent-change")
+        ).toBe("main..parent-change")
     })
 
     test("apply skips empty plans", async () => {

--- a/tests/unit/stack/executor.test.ts
+++ b/tests/unit/stack/executor.test.ts
@@ -87,6 +87,7 @@ mock.module("../../../src/commander/operations", () => ({
         calls.push(`rebase:${name}:${destination}`)
         return result("jj rebase")
     }),
+    jjRevsetHasMatches: mock(async () => false),
     jjAbandon: mock(async (revision: string) => {
         calls.push(`abandon:${revision}`)
         return result("jj abandon")

--- a/tests/unit/stack/executor.test.ts
+++ b/tests/unit/stack/executor.test.ts
@@ -122,6 +122,28 @@ describe("stack executor", () => {
         ).toBe("parent-change")
     })
 
+    test("apply skips empty plans", async () => {
+        calls.length = 0
+        const plan: StackPlan<Bookmark> = {
+            kind: "sync",
+            stackRootName: "test/stack",
+            rows: [],
+            effects: [],
+            updatePrNumbers: [],
+            createPrBookmarks: [],
+            pushBookmarks: [],
+            rebaseBookmarks: [],
+            abandonBookmarks: [],
+            closePrNumbers: [],
+            applyCommand: "stack sync",
+        }
+
+        const { applyStackPlan } = await import("../../../src/stack/executor")
+        await Effect.runPromise(applyStackPlan(plan))
+
+        expect(calls).toEqual([])
+    })
+
     test("sync apply abandons merged roots before rebasing and pushing descendants", async () => {
         calls.length = 0
         const plan: StackPlan<Bookmark> = {

--- a/tests/unit/stack/planner.test.ts
+++ b/tests/unit/stack/planner.test.ts
@@ -158,6 +158,9 @@ describe("stack planners", () => {
         expect(plan.rebaseBookmarks).toEqual(["feature-b"])
         expect(plan.pushBookmarks).toEqual(["feature-b"])
         expect(plan.updatePrNumbers).toEqual([11])
+        expect(
+            plan.effects.find((effect) => effect.type === "abandon")?.revision,
+        ).toBe("main..a")
     })
 
     test("sync plans rebases when GitHub PR base differs from local target", async () => {

--- a/tests/unit/stack/planner.test.ts
+++ b/tests/unit/stack/planner.test.ts
@@ -1,10 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import { Effect } from "effect"
 import { buildBookmarkStackModel } from "../../../src/stack/discovery"
-import {
-    buildSubmitPlanSync,
-    buildSyncPlanSync,
-} from "../../../src/stack/planner"
+import { buildSyncPlanSync } from "../../../src/stack/planner"
 
 const commits = [
     { commitId: "main", parentCommitIds: [], immutable: true },
@@ -22,8 +19,8 @@ const model = async () =>
     Effect.runPromise(buildBookmarkStackModel({ commits, bookmarks }))
 
 describe("stack planners", () => {
-    test("submit plans PR creation, retargeting and pushes", async () => {
-        const plan = buildSubmitPlanSync({
+    test("sync plans PR creation, retargeting and pushes", async () => {
+        const plan = buildSyncPlanSync({
             stackRootName: "feature-a",
             stackModel: await model(),
             pullRequestsByHead: new Map([
@@ -45,8 +42,8 @@ describe("stack planners", () => {
             plan.rows.map((row) => [row.row.bookmark.name, row.note]),
         ).toEqual([
             ["main", ""],
-            ["feature-a", "would retarget PR onto main"],
-            ["feature-b", "would create PR onto feature-a"],
+            ["feature-a", "would push and retarget PR onto main"],
+            ["feature-b", "would push and create PR onto feature-a"],
         ])
         expect(plan.updatePrNumbers).toEqual([10])
         expect(plan.createPrBookmarks).toEqual(["feature-b"])
@@ -163,7 +160,32 @@ describe("stack planners", () => {
         ).toBe("main..a")
     })
 
-    test("sync plans rebases when GitHub PR base differs from local target", async () => {
+    test("sync plans landed parent range repair from persisted state", async () => {
+        const plan = buildSyncPlanSync({
+            stackRootName: "feature-a",
+            stackModel: await model(),
+            pullRequestsByHead: new Map([
+                [
+                    "feature-b",
+                    {
+                        number: 11,
+                        headRefName: "feature-b",
+                        baseRefName: "main",
+                        state: "OPEN",
+                    },
+                ],
+            ]),
+            landedRangesByBookmark: new Map([
+                ["feature-b", "(main..a) & ancestors(b) ~ ancestors(main)"],
+            ]),
+        })
+
+        expect(plan.rows[2]?.status).toBe("abandon-landed-range")
+        expect(plan.rows[2]?.note).toBe("would abandon landed parent range")
+        expect(plan.abandonBookmarks).toEqual(["feature-b"])
+    })
+
+    test("sync plans PR retargets when GitHub PR base differs from local target", async () => {
         const plan = buildSyncPlanSync({
             stackRootName: "feature-a",
             stackModel: await model(),
@@ -183,9 +205,9 @@ describe("stack planners", () => {
             plan.rows.map((row) => [row.row.bookmark.name, row.note]),
         ).toEqual([
             ["main", ""],
-            ["feature-a", "targets main"],
-            ["feature-b", "would rebase and push onto main"],
+            ["feature-a", "would push and create PR onto main"],
+            ["feature-b", "would push and retarget PR onto feature-a"],
         ])
-        expect(plan.rebaseBookmarks).toEqual(["feature-b"])
+        expect(plan.updatePrNumbers).toEqual([11])
     })
 })

--- a/tests/unit/stack/planner.test.ts
+++ b/tests/unit/stack/planner.test.ts
@@ -9,14 +9,32 @@ const commits = [
     { commitId: "b", parentCommitIds: ["a"], immutable: false },
 ]
 
+const threeBookmarkCommits = [
+    ...commits,
+    { commitId: "c", parentCommitIds: ["b"], immutable: false },
+]
+
 const bookmarks = [
     { name: "main", commitId: "main", changeId: "main" },
     { name: "feature-a", commitId: "a", changeId: "a" },
     { name: "feature-b", commitId: "b", changeId: "b" },
 ]
 
+const threeBookmarks = [
+    ...bookmarks,
+    { name: "feature-c", commitId: "c", changeId: "c" },
+]
+
 const model = async () =>
     Effect.runPromise(buildBookmarkStackModel({ commits, bookmarks }))
+
+const threeBookmarkModel = async () =>
+    Effect.runPromise(
+        buildBookmarkStackModel({
+            commits: threeBookmarkCommits,
+            bookmarks: threeBookmarks,
+        }),
+    )
 
 describe("stack planners", () => {
     test("sync plans PR creation, retargeting and pushes", async () => {
@@ -158,6 +176,195 @@ describe("stack planners", () => {
         expect(
             plan.effects.find((effect) => effect.type === "abandon")?.revision,
         ).toBe("main..a")
+    })
+
+    test("sync pushes descendants after a branch rebase", async () => {
+        const plan = buildSyncPlanSync({
+            stackRootName: "feature-a",
+            stackModel: await threeBookmarkModel(),
+            pullRequestsByHead: new Map([
+                [
+                    "feature-a",
+                    {
+                        number: 10,
+                        headRefName: "feature-a",
+                        baseRefName: "main",
+                        state: "MERGED",
+                        merged: true,
+                    },
+                ],
+                [
+                    "feature-b",
+                    {
+                        number: 11,
+                        headRefName: "feature-b",
+                        baseRefName: "feature-a",
+                        state: "OPEN",
+                    },
+                ],
+                [
+                    "feature-c",
+                    {
+                        number: 12,
+                        headRefName: "feature-c",
+                        baseRefName: "feature-b",
+                        state: "OPEN",
+                    },
+                ],
+            ]),
+            remoteBookmarksByName: new Map([
+                ["feature-a", { name: "feature-a", commitId: "a" }],
+                ["feature-b", { name: "feature-b", commitId: "b" }],
+                ["feature-c", { name: "feature-c", commitId: "c" }],
+            ]),
+        })
+
+        expect(plan.rows[2]?.effects.map((effect) => effect.type)).toEqual([
+            "rebase",
+            "push",
+            "update-pr",
+        ])
+        expect(plan.rows[3]?.effects.map((effect) => effect.type)).toEqual([
+            "push",
+        ])
+    })
+
+    test("sync keeps a merged local bookmark while remote bookmark still exists", async () => {
+        const plan = buildSyncPlanSync({
+            stackRootName: "feature-a",
+            stackModel: await model(),
+            pullRequestsByHead: new Map([
+                [
+                    "feature-a",
+                    {
+                        number: 10,
+                        headRefName: "feature-a",
+                        baseRefName: "main",
+                        state: "MERGED",
+                        merged: true,
+                    },
+                ],
+                [
+                    "feature-b",
+                    {
+                        number: 11,
+                        headRefName: "feature-b",
+                        baseRefName: "feature-a",
+                        state: "OPEN",
+                    },
+                ],
+            ]),
+            remoteBookmarksByName: new Map([
+                ["feature-a", { name: "feature-a", commitId: "a" }],
+                ["feature-b", { name: "feature-b", commitId: "b" }],
+            ]),
+        })
+
+        expect(plan.rows[1]?.effects.map((effect) => effect.type)).toEqual([])
+        expect(plan.rows[2]?.effects.map((effect) => effect.type)).toEqual([
+            "rebase",
+            "push",
+            "update-pr",
+        ])
+        expect(plan.abandonBookmarks).toEqual([])
+    })
+
+    test("sync does not update stack comments when stack contains merged PRs", async () => {
+        const plan = buildSyncPlanSync({
+            stackRootName: "feature-a",
+            stackModel: await model(),
+            pullRequestsByHead: new Map([
+                [
+                    "feature-a",
+                    {
+                        number: 10,
+                        headRefName: "feature-a",
+                        baseRefName: "main",
+                        state: "MERGED",
+                        merged: true,
+                    },
+                ],
+                [
+                    "feature-b",
+                    {
+                        number: 11,
+                        headRefName: "feature-b",
+                        baseRefName: "feature-a",
+                        state: "OPEN",
+                    },
+                ],
+            ]),
+            remoteBookmarksByName: new Map([
+                ["feature-a", { name: "feature-a", commitId: "a" }],
+                ["feature-b", { name: "feature-b", commitId: "b" }],
+            ]),
+        })
+
+        expect(
+            plan.effects.some((effect) => effect.type === "update-comment"),
+        ).toBe(false)
+    })
+
+    test("sync does not also plan landed range repair for an already-merged PR", async () => {
+        const plan = buildSyncPlanSync({
+            stackRootName: "feature-a",
+            stackModel: await model(),
+            pullRequestsByHead: new Map([
+                [
+                    "feature-b",
+                    {
+                        number: 11,
+                        headRefName: "feature-b",
+                        baseRefName: "main",
+                        state: "MERGED",
+                        merged: true,
+                    },
+                ],
+            ]),
+            landedRangesByBookmark: new Map([
+                ["feature-b", "(main..a) & ancestors(b) ~ ancestors(main)"],
+            ]),
+        })
+
+        expect(plan.rows[2]?.effects.map((effect) => effect.type)).toEqual([
+            "abandon",
+        ])
+    })
+
+    test("sync does not plan child landed range when parent is being abandoned", async () => {
+        const plan = buildSyncPlanSync({
+            stackRootName: "feature-a",
+            stackModel: await model(),
+            pullRequestsByHead: new Map([
+                [
+                    "feature-a",
+                    {
+                        number: 10,
+                        headRefName: "feature-a",
+                        baseRefName: "main",
+                        state: "MERGED",
+                        merged: true,
+                    },
+                ],
+                [
+                    "feature-b",
+                    {
+                        number: 11,
+                        headRefName: "feature-b",
+                        baseRefName: "main",
+                        state: "OPEN",
+                    },
+                ],
+            ]),
+            landedRangesByBookmark: new Map([
+                ["feature-b", "(main..a) & ancestors(b) ~ ancestors(main)"],
+            ]),
+        })
+
+        expect(plan.rows[2]?.effects.map((effect) => effect.type)).toEqual([
+            "rebase",
+            "push",
+        ])
     })
 
     test("sync plans landed parent range repair from persisted state", async () => {

--- a/tests/unit/stack/planner.test.ts
+++ b/tests/unit/stack/planner.test.ts
@@ -87,7 +87,77 @@ describe("stack planners", () => {
             ["feature-a", "blocked"],
             ["feature-b", "close-pr"],
         ])
+        expect(plan.rows[2]?.note).toBe(
+            "would close PR: parent #10 was closed without merging",
+        )
         expect(plan.closePrNumbers).toEqual([11])
+    })
+
+    test("sync plans descendant PR closure even if GitHub state is missing", async () => {
+        const plan = buildSyncPlanSync({
+            stackRootName: "feature-a",
+            stackModel: await model(),
+            pullRequestsByHead: new Map([
+                [
+                    "feature-a",
+                    {
+                        number: 10,
+                        headRefName: "feature-a",
+                        baseRefName: "main",
+                        state: "CLOSED",
+                        merged: false,
+                    },
+                ],
+                [
+                    "feature-b",
+                    {
+                        number: 11,
+                        headRefName: "feature-b",
+                        baseRefName: "feature-a",
+                    },
+                ],
+            ]),
+        })
+
+        expect(plan.rows[2]?.status).toBe("close-pr")
+        expect(plan.closePrNumbers).toEqual([11])
+    })
+
+    test("sync plans rebase and retarget descendants of merged parents", async () => {
+        const plan = buildSyncPlanSync({
+            stackRootName: "feature-a",
+            stackModel: await model(),
+            pullRequestsByHead: new Map([
+                [
+                    "feature-a",
+                    {
+                        number: 10,
+                        headRefName: "feature-a",
+                        baseRefName: "main",
+                        state: "MERGED",
+                        merged: true,
+                    },
+                ],
+                [
+                    "feature-b",
+                    {
+                        number: 11,
+                        headRefName: "feature-b",
+                        baseRefName: "feature-a",
+                        state: "OPEN",
+                    },
+                ],
+            ]),
+        })
+
+        expect(plan.rows[1]?.note).toBe("would abandon merged local change")
+        expect(plan.rows[2]?.note).toBe(
+            "would rebase, push, and retarget onto main",
+        )
+        expect(plan.abandonBookmarks).toEqual(["feature-a"])
+        expect(plan.rebaseBookmarks).toEqual(["feature-b"])
+        expect(plan.pushBookmarks).toEqual(["feature-b"])
+        expect(plan.updatePrNumbers).toEqual([11])
     })
 
     test("sync plans rebases when GitHub PR base differs from local target", async () => {
@@ -111,7 +181,7 @@ describe("stack planners", () => {
         ).toEqual([
             ["main", ""],
             ["feature-a", "targets main"],
-            ["feature-b", "would rebase onto main"],
+            ["feature-b", "would rebase and push onto main"],
         ])
         expect(plan.rebaseBookmarks).toEqual(["feature-b"])
     })

--- a/tests/unit/stack/planner.test.ts
+++ b/tests/unit/stack/planner.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import { buildBookmarkStackModel } from "../../../src/stack/discovery"
+import {
+    buildSubmitPlanSync,
+    buildSyncPlanSync,
+} from "../../../src/stack/planner"
+
+const commits = [
+    { commitId: "main", parentCommitIds: [], immutable: true },
+    { commitId: "a", parentCommitIds: ["main"], immutable: false },
+    { commitId: "b", parentCommitIds: ["a"], immutable: false },
+]
+
+const bookmarks = [
+    { name: "main", commitId: "main", changeId: "main" },
+    { name: "feature-a", commitId: "a", changeId: "a" },
+    { name: "feature-b", commitId: "b", changeId: "b" },
+]
+
+const model = async () =>
+    Effect.runPromise(buildBookmarkStackModel({ commits, bookmarks }))
+
+describe("stack planners", () => {
+    test("submit plans PR creation, retargeting and pushes", async () => {
+        const plan = buildSubmitPlanSync({
+            stackRootName: "feature-a",
+            stackModel: await model(),
+            pullRequestsByHead: new Map([
+                [
+                    "feature-a",
+                    {
+                        number: 10,
+                        headRefName: "feature-a",
+                        baseRefName: "old",
+                    },
+                ],
+            ]),
+            remoteBookmarksByName: new Map([
+                ["feature-a", { name: "feature-a", commitId: "old-a" }],
+            ]),
+        })
+
+        expect(
+            plan.rows.map((row) => [row.row.bookmark.name, row.note]),
+        ).toEqual([
+            ["main", ""],
+            ["feature-a", "would retarget PR onto main"],
+            ["feature-b", "would create PR onto feature-a"],
+        ])
+        expect(plan.updatePrNumbers).toEqual([10])
+        expect(plan.createPrBookmarks).toEqual(["feature-b"])
+        expect(plan.pushBookmarks).toEqual(["feature-a", "feature-b"])
+    })
+
+    test("sync plans rebases when GitHub PR base differs from local target", async () => {
+        const plan = buildSyncPlanSync({
+            stackRootName: "feature-a",
+            stackModel: await model(),
+            pullRequestsByHead: new Map([
+                [
+                    "feature-b",
+                    {
+                        number: 11,
+                        headRefName: "feature-b",
+                        baseRefName: "main",
+                    },
+                ],
+            ]),
+        })
+
+        expect(
+            plan.rows.map((row) => [row.row.bookmark.name, row.note]),
+        ).toEqual([
+            ["main", ""],
+            ["feature-a", "targets main"],
+            ["feature-b", "would rebase onto main"],
+        ])
+        expect(plan.rebaseBookmarks).toEqual(["feature-b"])
+    })
+})

--- a/tests/unit/stack/planner.test.ts
+++ b/tests/unit/stack/planner.test.ts
@@ -53,6 +53,43 @@ describe("stack planners", () => {
         expect(plan.pushBookmarks).toEqual(["feature-a", "feature-b"])
     })
 
+    test("sync plans closed-unmerged parent effects before apply", async () => {
+        const plan = buildSyncPlanSync({
+            stackRootName: "feature-a",
+            stackModel: await model(),
+            pullRequestsByHead: new Map([
+                [
+                    "feature-a",
+                    {
+                        number: 10,
+                        headRefName: "feature-a",
+                        baseRefName: "main",
+                        state: "CLOSED",
+                        merged: false,
+                    },
+                ],
+                [
+                    "feature-b",
+                    {
+                        number: 11,
+                        headRefName: "feature-b",
+                        baseRefName: "feature-a",
+                        state: "OPEN",
+                    },
+                ],
+            ]),
+        })
+
+        expect(
+            plan.rows.map((row) => [row.row.bookmark.name, row.status]),
+        ).toEqual([
+            ["main", "current"],
+            ["feature-a", "blocked"],
+            ["feature-b", "close-pr"],
+        ])
+        expect(plan.closePrNumbers).toEqual([11])
+    })
+
     test("sync plans rebases when GitHub PR base differs from local target", async () => {
         const plan = buildSyncPlanSync({
             stackRootName: "feature-a",


### PR DESCRIPTION
## Summary

Adds an experimental GitHub PR stacking workflow for jj bookmarks, gated behind `KAJJI_ENABLE_STACKING=1`.

When enabled, the bookmarks panel can render stacked bookmark relationships, show PR numbers, and open a stack sync flow that previews and applies GitHub/jj reconciliation work.

## What changed

- Add shared bookmark stack discovery/modeling from jj commit parent relationships.
- Render nested bookmark stacks in the bookmarks panel, including active-stack dimming.
- Add GitHub PR metadata lookup for bookmark heads and show known PR numbers inline.
- Add stack action, preparing, and sync preview modals.
- Consolidate stack operations around `sync` rather than separate submit/sync actions.
- Add stack sync planning/execution for:
  - pushing stack bookmarks
  - creating missing PRs
  - retargeting PR bases
  - rebasing descendants after merged stack parents
  - abandoning landed/merged local ranges when needed
  - updating managed stack comments
- Persist stack metadata under the resolved jj repo state directory for later repair after fetch/out-of-band merges.
- Add tests for GitHub PR parsing, stack discovery, sync planning, and sync execution.
- Gate the stack UI/action/model rendering behind `KAJJI_ENABLE_STACKING=1`.

## Feature flag

Stacking is disabled by default. To try it:

```sh
KAJJI_ENABLE_STACKING=1 kajji
```

## Notes

This is intentionally experimental. The current implementation keeps the UI hidden unless the flag is set, while leaving generic PR-number lookup available for normal PR open flows. Follow-up work should migrate the stack executor toward proper Effect services and add stack-aware merge.
